### PR TITLE
feat: add --watch flag for real-time polling on read subcommands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry-backend: s3
           registry-backend-s3-bucket: altf4llc-vorpal-registry
-          version: nightly
+          version: 0.1.0-alpha.0
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
@@ -58,7 +58,7 @@ jobs:
         with:
           registry-backend: s3
           registry-backend-s3-bucket: altf4llc-vorpal-registry
-          version: nightly
+          version: 0.1.0-alpha.0
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -1,0 +1,252 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "System architecture of the docket CLI issue tracker: components, data flow, module boundaries, and key design decisions"
+owner: "@staff-engineer"
+dependencies:
+  - security.md
+  - operations.md
+  - performance.md
+---
+
+# Architecture
+
+## 1. System Overview
+
+Docket is a **local-first CLI issue tracker** that stores all data in a single SQLite database within the project directory. It is designed for developer-centric workflows where issues live alongside the code, with no external services, accounts, or network dependencies required.
+
+The project tagline from the CLI is: **"Local-first CLI issue tracker"**.
+
+### Key Design Principles
+
+- **Local-first**: All state is in a single SQLite file (`.docket/issues.db`), co-located with the project. No server, no network, no accounts.
+- **CLI-native**: Primary interface is the terminal. All commands support dual-mode output (human-readable with color/styling, or structured JSON via `--json`).
+- **Single-binary**: Built as a statically-linked Go binary (`CGO_ENABLED=0`) using the pure-Go `modernc.org/sqlite` driver. No C dependencies at runtime.
+- **Git-friendly**: Data directory (`.docket/`) is designed to live in a project root. Author resolution falls back to `git config user.name`.
+
+## 2. High-Level Architecture
+
+```
+cmd/docket/main.go          -- Entry point: delegates to cli.Execute()
+cmd/vorpal/main.go           -- Vorpal build system configuration (dev tooling)
+
+internal/
+  cli/                        -- Command definitions (cobra commands)
+  config/                     -- Configuration resolution (DOCKET_PATH / cwd)
+  db/                         -- Database access layer (SQLite)
+  model/                      -- Domain types and validation
+  filter/                     -- Shared filtering utilities
+  planner/                    -- DAG construction, topological sort, execution planning
+  render/                     -- Terminal rendering (board, table, detail, markdown, vote)
+  output/                     -- Output dispatch (JSON envelope vs. human formatting)
+```
+
+The architecture follows a **layered pattern** with clear separation:
+
+```
+CLI Commands (internal/cli)
+    |
+    v
+Output Layer (internal/output)  <-->  Render Layer (internal/render)
+    |
+    v
+Business Logic (internal/planner, internal/filter)
+    |
+    v
+Data Access (internal/db)
+    |
+    v
+Domain Model (internal/model)
+    |
+    v
+SQLite (modernc.org/sqlite) -- .docket/issues.db
+```
+
+## 3. Component Details
+
+### 3.1 Entry Points
+
+**`cmd/docket/main.go`**: Minimal entry point. Calls `cli.Execute()` and passes its return value to `os.Exit()`.
+
+**`cmd/vorpal/main.go`**: Build system configuration using ALT-F4-LLC's Vorpal SDK. Defines the development environment (Go toolchain, staticcheck, protoc, ffmpeg, vhs, ttyd) and the release build artifact. Targets: `aarch64-darwin`, `aarch64-linux`, `x86_64-darwin`, `x86_64-linux`.
+
+### 3.2 CLI Layer (`internal/cli`)
+
+Built on **spf13/cobra**. The root command (`docket`) defines:
+
+- Global flags: `--json` (structured output), `--quiet` (suppress non-essential output)
+- `PersistentPreRunE`: Resolves config, opens SQLite DB, runs migrations. Commands annotated with `skipDB` bypass DB initialization (e.g., `init`).
+- `PersistentPostRunE`: Closes the DB connection.
+- Version info injected via ldflags at build time (`version`, `commit`, `buildDate`).
+
+**Command tree:**
+
+| Command | Subcommands | Description |
+|---------|-------------|-------------|
+| `init` | -- | Create `.docket/` directory and initialize schema |
+| `board` | -- | Kanban board view (columns by status) |
+| `plan` | -- | DAG-based execution plan with phased grouping |
+| `next` | -- | Work-ready issues (unblocked leaf tasks) |
+| `stats` | -- | Summary statistics (counts by status/priority/label) |
+| `export` | -- | Export to JSON, CSV, or Markdown |
+| `import` | -- | Import from JSON export file (default/merge/replace modes) |
+| `version` | -- | Show version information |
+| `config` | -- | Show resolved configuration |
+| `issue` | `create`, `list`, `show`, `edit`, `close`, `reopen`, `delete`, `move`, `comment`, `label`, `link`, `graph`, `log`, `file` | Full issue lifecycle management |
+| `issue comment` | `list` | Comment sub-operations |
+| `vote` | `create`, `cast`, `show`, `list`, `result`, `commit`, `link` | PBFT-inspired consensus voting |
+
+**Error handling**: Commands return `*CmdError` wrapping an error with a machine-readable `ErrorCode`. The `Execute()` function maps these to structured JSON error envelopes or styled human error output with distinct exit codes (0=success, 1=general, 2=not-found, 3=validation, 4=conflict).
+
+**Interactive forms**: Issue creation uses `charmbracelet/huh` for interactive TUI forms when `--title` is not provided and JSON mode is off. Import with `--replace` prompts for confirmation.
+
+### 3.3 Configuration (`internal/config`)
+
+Resolution order:
+1. `DOCKET_PATH` environment variable (if set)
+2. `$PWD/.docket` (default)
+
+Configuration is a simple struct:
+- `DocketDir`: Path to the `.docket` directory
+- `DBPath`: Full path to `issues.db` within `DocketDir`
+- `EnvVarSet`: Whether `DOCKET_PATH` was used
+
+Author resolution (`DefaultAuthor()`): Tries `git config user.name` with a 2-second timeout, falls back to OS username, ultimate fallback is `"unknown"`. Result is cached via `sync.Once`.
+
+### 3.4 Data Access Layer (`internal/db`)
+
+**Connection management**: Opens SQLite via `modernc.org/sqlite` (pure Go, no CGO). Sets `MaxOpenConns(1)` to avoid lock contention. Configures pragmas:
+- `journal_mode=WAL` (concurrent reads)
+- `foreign_keys=ON` (referential integrity)
+- `busy_timeout=5000` (5s retry on lock)
+
+**Schema versioning**: Uses a `meta` table with a `schema_version` key. Schema is at version 3. Migrations run sequentially in transactions:
+- v1: Base schema (issues, comments, labels, issue_labels, issue_relations, activity_log, issue_files)
+- v2: Vote system (proposals, votes, proposal_issues)
+- v3: Enhanced vote tracking (rationale, domain_tags, files_changed, final_outcome, escalation_reason, findings_json, summary)
+
+Includes a repair mechanism for databases stamped as v2 but missing the proposals table (from a buggy `Initialize()`).
+
+**Data access pattern**: Direct SQL queries using `database/sql`. No ORM. Functions accept `*sql.DB` or `*sql.Tx` and return domain model types. Sentinel error `ErrNotFound` for missing entities.
+
+### 3.5 Domain Model (`internal/model`)
+
+Core types with validation and custom JSON marshaling/unmarshaling:
+
+**Issue**: The central entity. Fields: ID, ParentID (nullable, self-referential hierarchy), Title, Description, Status, Priority, Kind, Assignee, Labels, Files, CreatedAt, UpdatedAt.
+
+- **Status** enum: `backlog` | `todo` | `in-progress` | `review` | `done`
+- **Priority** enum: `critical` | `high` | `medium` | `low` | `none`
+- **IssueKind** enum: `bug` | `feature` | `task` | `epic` | `chore`
+- **ID format**: `DKT-{n}` (e.g., `DKT-5`). `ParseID()` accepts both `DKT-5` and `5`.
+
+All enum types implement `Color()` and `Icon()` methods for terminal rendering.
+
+**Relation**: Typed link between two issues. Types: `blocks`, `depends_on`, `relates_to`, `duplicates`. A database trigger prevents inverse duplicate relations. `ParseRelationType()` normalizes hyphens to underscores.
+
+**Proposal** (vote system): ID prefix `DKT-V`. Fields: Description, Criticality (`low`|`medium`|`high`|`critical`), Status (`open`|`approved`|`rejected`|`committed`), RequiredVoters, Threshold, WeightedScore, Rationale, DomainTags, FilesChanged, FinalOutcome, EscalationReason.
+
+**Vote**: Individual vote on a proposal. Fields: VoterName, VoterRole, Verdict (`approve`|`approve-with-concerns`|`reject`), Confidence, DomainRelevance, Findings, FindingsJSON (structured: blockers/concerns/suggestions), Summary.
+
+**ExportData**: Full database export envelope containing issues, comments, relations, labels, and all join-table mappings.
+
+### 3.6 Planner (`internal/planner`)
+
+Implements dependency-aware execution planning:
+
+1. **DAG construction** (`BuildDAG`): Takes issues and relations. Normalizes `blocks` and `depends_on` into a single edge direction (forward = blocker-to-blocked, reverse = blocked-to-blocker). `relates_to` and `duplicates` are ignored for ordering.
+
+2. **Topological sort** (`TopoSort`): Kahn's algorithm producing level-grouped output. Returns `CycleError` listing involved issue IDs when cycles are detected.
+
+3. **Plan generation** (`GeneratePlan`): Groups issues into parallelizable phases by topological level. Applies filters (status, label, root scoping). Splits phases by file collision detection -- issues touching the same file are placed in separate sub-phases.
+
+4. **Ready issue detection** (`FindReady`): Finds unblocked leaf tasks (no children, all blockers done) in specified statuses. Sorted by priority (highest first), then ID (oldest first).
+
+5. **Adjacency helpers** (`BuildAdjacency`): Builds forward/backward adjacency lists for graph traversal (used by `issue graph`).
+
+### 3.7 Output Layer (`internal/output`)
+
+**`Writer`** struct dispatches between JSON and human output modes:
+
+- **JSON mode** (`--json`): Wraps all output in a standardized envelope: `{"ok": true, "data": ..., "message": "..."}` for success, `{"ok": false, "error": "...", "code": "..."}` for errors. Written to stdout.
+- **Human mode**: Styled terminal output using lipgloss. Success messages get a checkmark prefix; multi-line content (tables, boards) is printed as-is. Errors go to stderr with styled prefix.
+- **Quiet mode** (`--quiet`): Suppresses info messages. Warnings still emit in human mode.
+- **Error codes**: `GENERAL_ERROR`, `NOT_FOUND`, `VALIDATION_ERROR`, `CONFLICT` -- mapped to exit codes 1-4.
+
+### 3.8 Render Layer (`internal/render`)
+
+Terminal rendering with automatic color detection and plain-text fallback:
+
+- **Board** (`board.go`): Kanban columns by status. Color mode uses lipgloss with rounded border cards showing kind icon, ID, priority icon, title, labels, and sub-issue progress bars. Adapts to terminal width. Caps at 10 cards per column with "+N more" overflow.
+- **Table** (`table.go`): Tabular issue list with aligned columns.
+- **Detail** (`detail.go`): Single-issue detail view with markdown rendering.
+- **Markdown** (`markdown.go`): Renders markdown content using `charmbracelet/glamour`.
+- **Vote** (`vote.go`): Proposal and vote result rendering.
+
+All renderers check `ColorsEnabled()` and fall back to plain text for non-TTY environments.
+
+### 3.9 Filter Utilities (`internal/filter`)
+
+Shared helpers for filtering across commands:
+- `ToStringSet()`: Converts string slices to maps for O(1) membership checks.
+- `HasAllLabels()`: AND-logic label matching (issue must have all required labels).
+
+## 4. Data Flow
+
+### Typical Command Execution
+
+```
+1. main() -> cli.Execute() -> cobra dispatches to command
+2. PersistentPreRunE:
+   a. config.Resolve() -> Config{DocketDir, DBPath}
+   b. db.Open(DBPath)  -> *sql.DB (WAL, FK, busy_timeout)
+   c. db.Migrate(conn) -> sequential schema migrations
+3. Command RunE:
+   a. Read flags
+   b. Query db layer
+   c. Apply business logic (planner, filter)
+   d. Render output (JSON envelope or human-styled)
+4. PersistentPostRunE: conn.Close()
+5. Return exit code
+```
+
+### Export/Import Cycle
+
+```
+Export: DB -> ListAll*() queries -> ExportData struct -> JSON/CSV/Markdown
+Import: JSON file -> Unmarshal + validate -> Transaction -> InsertWithID (idempotent in merge mode)
+```
+
+## 5. External Dependencies (Runtime)
+
+| Dependency | Purpose | Notes |
+|-----------|---------|-------|
+| `modernc.org/sqlite` | SQLite database driver | Pure Go, no CGO required |
+| `spf13/cobra` | CLI framework | Command routing, flag parsing |
+| `charmbracelet/lipgloss` | Terminal styling | Colors, borders, layout |
+| `charmbracelet/glamour` | Markdown rendering | Used for issue descriptions |
+| `charmbracelet/huh` | Interactive forms | Issue creation, import confirmation |
+| `dustin/go-humanize` | Human-friendly formatting | Time display |
+| `golang.org/x/term` | Terminal dimensions | Board column width calculation |
+
+## 6. Build and Distribution
+
+- **Build**: `CGO_ENABLED=0 go build` with ldflags for version/commit/date injection.
+- **Targets**: 4 platform targets via Vorpal: `{aarch64,x86_64}-{darwin,linux}`.
+- **Dev environment**: Vorpal SDK manages Go toolchain, staticcheck, goimports, gopls, protoc, vhs, ttyd, ffmpeg.
+- **Makefile targets**: `build`, `test`, `lint`, `vet`, `install`, `clean`, `demo`.
+- **CI**: GitHub Actions workflows present (`.github/workflows/`).
+
+## 7. Architectural Gaps and Observations
+
+- **No authentication/authorization**: By design (local-first), there is no access control. The database file is readable/writable by anyone with filesystem access.
+- **No server/API mode**: Purely CLI. No REST API, gRPC, or web interface exists.
+- **Single-writer constraint**: `MaxOpenConns(1)` means only one CLI process should write at a time. WAL mode allows concurrent reads but the 5s busy_timeout is the only concurrency guard.
+- **No automated backups**: No built-in mechanism for snapshots or backup beyond the export command.
+- **Activity log is write-only**: The `activity_log` table records field changes but the `issue log` command is the only consumer. No undo/rollback capability is built on top of it.
+- **Schema migration is forward-only**: No down-migrations. Rollback requires restoring from a backup or export.
+- **Vote system (v2-v3) is relatively new**: Added via recent migrations with a repair mechanism, suggesting rapid iteration. The PBFT-inspired model is sophisticated for a local tool and appears designed for multi-agent AI workflow integration.
+- **No test for CLI commands**: Tests exist for `db`, `model`, `planner`, `render`, and `output` packages but not for the `cli` package itself (command integration tests are absent).
+- **Protobuf tooling in dev env but no .proto files**: The Vorpal build includes protoc and protoc-gen-go but no `.proto` files exist in the repository, suggesting planned but not yet implemented gRPC support.

--- a/docs/spec/code-quality.md
+++ b/docs/spec/code-quality.md
@@ -1,0 +1,225 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Code quality standards, conventions, tooling, and patterns observed in the docket codebase"
+owner: "@staff-engineer"
+dependencies:
+  - testing.md
+---
+
+# Code Quality
+
+## Overview
+
+Docket is a Go CLI project (Go 1.26) structured as a single-module monorepo. The codebase follows idiomatic Go conventions with a clean separation between CLI, business logic, data access, and rendering layers. There are no third-party linter configurations checked into the repository (no `.golangci-lint.yaml`, `.editorconfig`, or similar). Static analysis relies on `go vet` and an optional `staticcheck` invocation via the Makefile.
+
+## Static Analysis and Linting
+
+### Current Tooling
+
+| Tool | Invocation | Enforcement |
+|------|-----------|-------------|
+| `go vet` | `make vet` (also a prerequisite of `make lint`) | Local only; not enforced in CI |
+| `staticcheck` | `make lint` — runs only if `staticcheck` binary is on `$PATH` | Optional; gracefully skipped if not installed |
+| `go build` | `make build` — CGO_ENABLED=0 | CI builds via Vorpal on all target platforms |
+
+### What Is Missing
+
+- **No golangci-lint configuration.** There is no `.golangci-lint.yaml` or equivalent meta-linter setup. Linting is limited to `go vet` and optional `staticcheck`.
+- **No CI lint step.** The GitHub Actions CI workflow (`ci.yaml`) only builds the project via Vorpal. It does not run `make lint`, `make vet`, or `make test`.
+- **No formatter enforcement.** There is no `gofmt`/`goimports` check in CI or pre-commit hooks. Formatting is assumed to be handled by developer editors.
+- **No pre-commit hooks.** No `.pre-commit-config.yaml` or git hooks are configured.
+- **No `.editorconfig`.** Editor settings are not standardized across contributors.
+
+## Naming Conventions
+
+### Package Names
+
+Packages use short, lowercase, single-word names following Go conventions:
+
+- `cli` — cobra command definitions
+- `db` — database access layer (SQLite)
+- `model` — domain types and validation
+- `config` — configuration resolution
+- `filter` — issue filtering utilities
+- `output` — output formatting dispatch (JSON/human)
+- `render` — terminal rendering (board, table, detail views)
+- `planner` — DAG construction and topological sorting
+
+### Variable and Function Naming
+
+- **Exported types** use PascalCase: `Issue`, `Proposal`, `Vote`, `Status`, `Priority`
+- **Unexported types** use camelCase: `issueJSON`, `proposalJSON`, `contextKey`
+- **Constants** use PascalCase for exported (`StatusBacklog`, `IDPrefix`) and camelCase for unexported (`dbKey`, `cfgKey`, `currentSchemaVersion`)
+- **Sentinel errors** use `Err` prefix: `ErrNotFound`, `ErrConflict`, `ErrSelfRelation`, `ErrCycleDetected`, `ErrDuplicateRelation`, `ErrNotAttached`, `ErrLabelColorConflict`
+- **Validation functions** follow `Validate<Type>` pattern: `ValidateStatus`, `ValidatePriority`, `ValidateIssueKind`, `ValidateCriticality`, `ValidateVerdict`
+- **Test helpers** use `must` prefix for fatal helpers: `mustOpen`, `mustInit`
+
+### File Naming
+
+- Source files use lowercase with underscores: `issue_create.go`, `vote_cast.go`, `activity.go`
+- Test files use the standard `_test.go` suffix
+- CLI subcommands follow `<noun>_<verb>.go` pattern: `issue_create.go`, `issue_close.go`, `vote_cast.go`, `vote_commit.go`
+- The parent command file is the bare noun: `issue.go`, `vote.go`
+
+## Type System Patterns
+
+### String-Typed Enums
+
+Domain enums are implemented as named `string` types with associated constants, validation functions, and display methods:
+
+```
+type Status string → StatusBacklog, StatusTodo, StatusInProgress, StatusReview, StatusDone
+type Priority string → PriorityCritical, PriorityHigh, PriorityMedium, PriorityLow, PriorityNone
+type IssueKind string → IssueKindBug, IssueKindFeature, IssueKindTask, IssueKindEpic, IssueKindChore
+type Criticality string → CriticalityLow, CriticalityMedium, CriticalityHigh, CriticalityCritical
+type ProposalStatus string → ProposalStatusOpen, ProposalStatusApproved, ProposalStatusRejected, ProposalStatusCommitted
+type Verdict string → VerdictApprove, VerdictApproveWithConcerns, VerdictReject
+```
+
+Each enum type consistently provides:
+- A `validXxx` slice for iteration
+- A `ValidateXxx(x) error` function
+- `.Color() string` and `.Icon() string` methods for terminal rendering (on Issue-related enums)
+
+### Custom JSON Serialization
+
+Domain types (`Issue`, `Proposal`, `Vote`, `Comment`) implement `MarshalJSON`/`UnmarshalJSON` using a private `xxxJSON` struct as the wire format. This pattern:
+- Converts internal int IDs to prefixed string IDs (`DKT-5`, `DKT-V1`)
+- Normalizes timestamps to RFC3339 UTC
+- Ensures nil slices serialize as `[]` instead of `null`
+- Validates enum values during deserialization
+
+### ID Formatting
+
+Two ID systems exist:
+- Issue IDs: `DKT-<n>` prefix (`FormatID` / `ParseID`)
+- Proposal IDs: `DKT-V<n>` prefix (`FormatProposalID` / `ParseProposalID`)
+
+Both parsers are case-insensitive and accept bare numeric input.
+
+## Error Handling Patterns
+
+### Sentinel Errors in `db` Package
+
+The `db` package defines sentinel errors for domain-specific failure cases:
+- `ErrNotFound` — entity does not exist
+- `ErrConflict` — concurrent modification or constraint violation
+- `ErrSelfRelation` — self-referential relation attempted
+- `ErrDuplicateRelation` — duplicate relation detected
+- `ErrCycleDetected` — cycle detected in dependency graph
+- `ErrNotAttached` — label not attached to issue
+- `ErrLabelColorConflict` — label color mismatch
+
+### CLI Error Wrapping
+
+The CLI layer wraps errors with `CmdError`, which pairs an `error` with a machine-readable `ErrorCode` (`GENERAL_ERROR`, `NOT_FOUND`, `VALIDATION_ERROR`, `CONFLICT`). The `cmdErr()` helper creates these. Each error code maps to a distinct exit code (0-4).
+
+### Error Propagation Pattern
+
+Errors are consistently wrapped with `fmt.Errorf("context: %w", err)` throughout the codebase, preserving the error chain for `errors.Is`/`errors.As` inspection. The `db` package wraps with action context (e.g., `"creating issue: %w"`), and the CLI layer wraps with user-facing context (e.g., `"reading description from stdin: %w"`).
+
+## Module Organization
+
+### Package Dependency Flow
+
+```
+cmd/docket/main.go
+  └── internal/cli (cobra commands)
+        ├── internal/config (configuration resolution)
+        ├── internal/db (data access — SQLite)
+        │     └── internal/model (domain types)
+        ├── internal/model (domain types — shared)
+        ├── internal/output (JSON/human output dispatch)
+        │     └── internal/render (terminal rendering)
+        ├── internal/filter (issue filtering)
+        └── internal/planner (DAG / topological sort)
+              └── internal/model
+```
+
+All application code lives under `internal/`, preventing external imports. There are no exported packages — docket is a standalone CLI binary.
+
+### Separation of Concerns
+
+- **`model`** — Pure data types, validation, and serialization. No database or I/O dependencies.
+- **`db`** — All SQL lives here. Functions accept `*sql.DB` as first argument. No CLI or rendering logic.
+- **`cli`** — Cobra command wiring. Reads flags, calls `db` functions, uses `output.Writer` for results.
+- **`output`** — Dispatch layer: routes between JSON (`json.go`) and human (`human.go`) output.
+- **`render`** — Terminal-specific rendering: board layout, tables, detail views, markdown. Uses lipgloss for styling.
+- **`config`** — Resolves `DOCKET_PATH` env var or falls back to `$PWD/.docket`.
+- **`filter`** — Stateless filtering utilities (label set membership).
+- **`planner`** — DAG construction from issue relations, topological sorting for execution planning.
+
+## Design Patterns
+
+### Context-Based Dependency Injection
+
+The CLI layer uses `context.Context` value injection to pass the database connection (`*sql.DB`) and configuration (`*config.Config`) through cobra's `PersistentPreRunE`/`PersistentPostRunE` hooks. Helper functions `getDB(cmd)` and `getCfg(cmd)` extract these from the command context.
+
+### Writer Pattern for Output
+
+`output.Writer` abstracts output formatting. Commands call `w.Success()`, `w.Error()`, `w.Info()`, and `w.Warn()` without knowing whether output is JSON or human-formatted. JSON mode produces structured envelopes (`{ok: true/false, data/error, ...}`). Human mode produces styled terminal output via lipgloss.
+
+### Interactive Fallback Pattern
+
+CLI commands support three modes: flags-only (for scripting/JSON), interactive forms (via charmbracelet/huh when flags are absent), and stdin piping (description from `-`). The pattern is: if `--json` and required flag missing, return validation error; if not `--json` and flag missing, launch interactive form.
+
+### Schema Migration Pattern
+
+The database uses a versioned migration system. `schema.go` defines `schemaDDL` for the initial schema and a `migrations` map keyed by target version. `Migrate()` applies pending migrations sequentially within transactions, updating the `meta.schema_version` row after each step. The system handles edge cases like databases stamped at a higher version than their actual state.
+
+## Build Configuration
+
+### Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `build` | `CGO_ENABLED=0 go build` with ldflags for version/commit/date |
+| `test` | `go test ./...` |
+| `lint` | `go vet` then optional `staticcheck` |
+| `vet` | `go vet ./...` |
+| `install` | `CGO_ENABLED=0 go install` with ldflags |
+| `clean` | Remove `./bin/` |
+| `demo` | Build then run VHS tape for terminal GIF |
+
+### Build Flags
+
+The build injects version metadata via ldflags:
+- `internal/cli.version` — git describe output
+- `internal/cli.commit` — short SHA
+- `internal/cli.buildDate` — UTC timestamp
+
+`CGO_ENABLED=0` is used for all builds, leveraging `modernc.org/sqlite` (a pure-Go SQLite implementation) to avoid CGO dependency.
+
+## CI/CD Pipeline
+
+### GitHub Actions (`ci.yaml`)
+
+The CI pipeline builds on a 4-platform matrix (macOS x86/ARM, Linux x86/ARM) using the Vorpal build system. It does **not** run tests, linting, or vetting — only builds the binary. Tagged pushes trigger a release job that:
+- Downloads build artifacts
+- Creates a GitHub release with platform-specific tarballs
+- Attests build provenance via `actions/attest-build-provenance`
+
+### Nightly (`ci-nightly.yaml`)
+
+A scheduled nightly workflow recreates a `nightly` tag pointing to `main`'s HEAD, enabling nightly release tracking. Uses a GitHub App token for authentication.
+
+## Gaps and Recommendations
+
+### Critical Gaps
+
+1. **No tests in CI.** `go test ./...` is not run in any CI workflow. Test regressions can ship to release.
+2. **No lint/vet in CI.** Static analysis is entirely local and optional.
+
+### Moderate Gaps
+
+3. **No golangci-lint.** The project would benefit from a meta-linter configuration to enforce consistent standards (unused code, error checking, import ordering, etc.).
+4. **No code coverage tracking.** There is no coverage reporting or threshold enforcement.
+5. **No formatter check.** `gofmt` correctness is not verified anywhere.
+
+### Minor Gaps
+
+6. **No `.editorconfig`.** Multi-contributor projects benefit from standardized editor settings.
+7. **No pre-commit hooks.** Catching lint/format issues before commit reduces CI feedback loops.

--- a/docs/spec/operations.md
+++ b/docs/spec/operations.md
@@ -1,0 +1,219 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "CI/CD pipelines, build system, release process, database operations, and operational characteristics of the docket CLI"
+owner: "@staff-engineer"
+dependencies:
+  - architecture.md
+  - security.md
+---
+
+# Operations
+
+## Overview
+
+Docket is a local-first CLI issue tracker backed by a single SQLite database file per project. It has no server component, no network services, and no runtime infrastructure to operate. Operational concerns center on: CI/CD pipelines, build/release automation, database lifecycle management, and developer environment tooling.
+
+## Build System
+
+### Vorpal Build System
+
+The project uses [Vorpal](https://github.com/ALT-F4-LLC/vorpal), an in-house Nix-inspired build system. Build configuration lives in two files:
+
+- **`Vorpal.toml`** -- declares the project language (Go) and source includes (`cmd/vorpal`, `go.mod`, `go.sum`).
+- **`cmd/vorpal/main.go`** -- Go-based build definition that configures two build artifacts:
+  - `docket-shell`: a development environment with Go toolchain, `goimports`, `gopls`, `staticcheck`, `protoc`, `protoc-gen-go`, `protoc-gen-go-grpc`, `ffmpeg`, `ttyd`, and `vhs`.
+  - `docket`: the production binary, built from `cmd/docket` with `CGO_ENABLED=0`.
+
+Vorpal uses an S3-backed artifact registry (`altf4llc-vorpal-registry`) for caching build artifacts. AWS credentials are required in CI.
+
+### Makefile
+
+A `Makefile` provides conventional local build targets:
+
+| Target    | Command                              | Notes                                    |
+|-----------|--------------------------------------|------------------------------------------|
+| `build`   | `go build` with ldflags              | Outputs to `./bin/docket`, CGO disabled  |
+| `test`    | `go test ./...`                      | Runs all tests                           |
+| `lint`    | `go vet` + `staticcheck`             | Staticcheck is optional (skipped if absent) |
+| `vet`     | `go vet ./...`                       | Subset of lint                           |
+| `install` | `go install` with ldflags            | CGO disabled                             |
+| `clean`   | `rm -rf ./bin/`                      | Removes build artifacts                  |
+| `demo`    | Builds then runs `vhs scripts/demo.tape` | Requires VHS installed                |
+
+### Version Injection
+
+Build version metadata is injected via `-ldflags` at compile time into `internal/cli`:
+
+- `version` -- from `git describe --tags --always --dirty` (defaults to `"dev"`)
+- `commit` -- from `git rev-parse --short HEAD` (defaults to `"none"`)
+- `buildDate` -- UTC timestamp (defaults to `"unknown"`)
+
+These are surfaced via `docket --version`.
+
+## CI/CD
+
+### Primary CI Pipeline (`.github/workflows/ci.yaml`)
+
+Triggered on: pull requests, pushes to `main`, and tag pushes.
+
+**Jobs:**
+
+1. **`build-shell`** -- Builds the `docket-shell` development environment across a 4-runner matrix:
+   - `macos-latest` (ARM64)
+   - `macos-latest-large` (x86_64)
+   - `ubuntu-latest` (x86_64)
+   - `ubuntu-latest-arm64` (ARM64)
+   - Uses `ALT-F4-LLC/setup-vorpal-action@main` to bootstrap Vorpal with S3 registry.
+   - Uploads `Vorpal.lock` as an artifact per architecture/OS.
+
+2. **`build`** -- Depends on `build-shell`. Same 4-runner matrix. Builds the `docket` binary, archives it as `docket-{arch}-{os}.tar.gz`, uploads as artifact.
+
+3. **`release`** -- Runs only on tag pushes (`refs/tags/*`). Downloads all build artifacts and creates a GitHub Release via `softprops/action-gh-release@v2`. Releases are marked as **prerelease**. Build provenance is attested via `actions/attest-build-provenance@v3`.
+
+**Permissions granted to release job:** `attestations: write`, `contents: write`, `id-token: write`, `packages: write`.
+
+### Nightly Pipeline (`.github/workflows/ci-nightly.yaml`)
+
+Triggered on: daily schedule (`0 8 * * *` UTC) and manual `workflow_dispatch`.
+
+Uses concurrency groups to cancel in-progress runs. Authenticates via a GitHub App token (`ALTF4LLC_GITHUB_APP_ID` / `ALTF4LLC_GITHUB_APP_PRIVATE_KEY`).
+
+**Behavior:** Deletes the existing `nightly` release and tag, then re-creates the `nightly` tag pointing at the current `main` HEAD SHA. This triggers the primary CI pipeline's release job to produce a fresh nightly build.
+
+### CI Secrets and Variables
+
+| Secret/Variable              | Purpose                         |
+|------------------------------|---------------------------------|
+| `AWS_ACCESS_KEY_ID`          | S3 registry access for Vorpal   |
+| `AWS_SECRET_ACCESS_KEY`      | S3 registry access for Vorpal   |
+| `AWS_DEFAULT_REGION`         | S3 region (stored as variable)  |
+| `ALTF4LLC_GITHUB_APP_ID`    | GitHub App for nightly releases |
+| `ALTF4LLC_GITHUB_APP_PRIVATE_KEY` | GitHub App private key     |
+
+## Release Process
+
+### Tag-Based Releases
+
+Releases are driven entirely by Git tags:
+
+1. Push a tag (e.g., `v0.1.0`) to trigger CI.
+2. CI builds cross-platform binaries (4 targets: macOS ARM64/x86_64, Linux ARM64/x86_64).
+3. Artifacts are packaged as `.tar.gz` archives.
+4. A GitHub Release is created with all archives.
+5. Build provenance attestation is attached.
+
+All releases are currently marked as **prerelease**, consistent with the project's experimental maturity.
+
+### Nightly Releases
+
+A rolling `nightly` release is automatically maintained. Each night at 08:00 UTC, the previous nightly release and tag are deleted and recreated from `main` HEAD.
+
+### No Versioned Release Process
+
+There is no changelog generation, semantic versioning automation, or release branch strategy. Tags are created manually.
+
+## Database Operations
+
+### Initialization
+
+`docket init` creates a `.docket/` directory (or uses `DOCKET_PATH`) containing `issues.db`. The SQLite database is initialized with the full schema DDL and stamped at schema version 1.
+
+### Auto-Migration
+
+On every command invocation (via `PersistentPreRunE`), the database is opened and `db.Migrate()` is called. This applies any pending migrations sequentially (currently v1->v2->v3). Migrations run within individual transactions; each migration bumps the schema version on success.
+
+The migration system includes a repair mechanism for databases incorrectly stamped at v2 without the proposals table -- it detects the missing table and re-runs migrations from v1.
+
+### Schema Versioning
+
+- Current schema version: **3**
+- Version is stored in a `meta` table (`key='schema_version'`).
+- Migration functions are registered in a `map[int]func(tx *sql.Tx) error`.
+
+### SQLite Configuration
+
+The database is configured with these pragmas on every open:
+
+| Pragma                | Value  | Purpose                                        |
+|-----------------------|--------|------------------------------------------------|
+| `journal_mode`        | `WAL`  | Write-Ahead Logging for concurrent read access |
+| `foreign_keys`        | `ON`   | Enforce referential integrity                  |
+| `busy_timeout`        | `5000` | 5-second wait before returning SQLITE_BUSY     |
+
+Connection pool is limited to 1 (`SetMaxOpenConns(1)`) since SQLite is single-writer.
+
+### Data Portability
+
+- **Export:** `docket export` outputs to JSON, CSV, or Markdown. Supports `--status` and `--label` filters. Can write to file (`-f`) or stdout.
+- **Import:** `docket import <file>` reads JSON export format. Three modes:
+  - Default: requires empty database.
+  - `--merge`: skips duplicate IDs.
+  - `--replace`: destructively clears all data first (with interactive confirmation in human mode).
+
+Import runs within a single transaction for atomicity. Export data is validated before any mutations.
+
+### Backup
+
+There is no built-in backup command. Since the database is a single file (`.docket/issues.db`), file-level copying suffices. WAL mode means the `-wal` and `-shm` files should be included in any backup, or a checkpoint should be forced first.
+
+## Error Handling and Exit Codes
+
+The CLI uses a structured error system with machine-readable error codes:
+
+| Exit Code | Error Code         | Meaning                       |
+|-----------|--------------------|-------------------------------|
+| 0         | --                 | Success                       |
+| 1         | `GENERAL_ERROR`    | Unexpected or internal error  |
+| 2         | `NOT_FOUND`        | Requested resource not found  |
+| 3         | `VALIDATION_ERROR` | Invalid input or arguments    |
+| 4         | `CONFLICT`         | Operation conflicts with state|
+
+In `--json` mode, errors are wrapped in a JSON envelope (`{"ok": false, "error": "...", "code": "..."}`). In human mode, errors are printed to stderr.
+
+## Output Modes
+
+The CLI supports three output modes controlled by global flags:
+
+- **Human mode** (default): Colored, styled output via lipgloss to stdout/stderr.
+- **JSON mode** (`--json`): Structured JSON envelopes to stdout. Info/warn messages suppressed.
+- **Quiet mode** (`-q`): Suppresses informational messages (warnings still shown).
+
+## Monitoring, Logging, and Observability
+
+**There is no monitoring, logging, or observability infrastructure.** This is consistent with docket's nature as a local-first CLI tool:
+
+- No structured logging framework (only `log.Fatalf` in the Vorpal build definition).
+- No metrics collection or export.
+- No tracing or OpenTelemetry integration.
+- No health checks or readiness probes.
+- No dashboards or alerting.
+
+Error reporting is entirely through CLI exit codes and stderr output.
+
+## Deployment Model
+
+Docket is distributed as a **static binary** (CGO disabled). There is no container image, no server deployment, no infrastructure to manage. Users download a platform-specific archive from GitHub Releases or build from source.
+
+### Supported Platforms
+
+| Architecture | OS    | CI Runner              |
+|-------------|-------|------------------------|
+| aarch64     | macOS | `macos-latest`         |
+| x86_64      | macOS | `macos-latest-large`   |
+| x86_64      | Linux | `ubuntu-latest`        |
+| aarch64     | Linux | `ubuntu-latest-arm64`  |
+
+## Operational Gaps
+
+The following are notable gaps relative to a production-grade CLI tool. These are documented for awareness, not as immediate action items -- several are appropriate for the project's current maturity level.
+
+- **No automated testing in CI**: The CI pipeline builds but does not run `go test` or `staticcheck`. Tests and linting are Makefile-only.
+- **No changelog or release notes automation**: Releases have no generated changelogs.
+- **No installation automation**: No Homebrew formula, no `go install` published path, no package manager integration.
+- **No backup/restore commands**: Users must manage SQLite file copies manually.
+- **No database integrity verification**: No `PRAGMA integrity_check` command or corrupted-database recovery path.
+- **No update/upgrade mechanism**: Users must manually download new releases.
+- **No telemetry or crash reporting**: Expected for a local-first tool, but means no visibility into real-world usage or failures.

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -1,0 +1,170 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Performance characteristics, database tuning, query patterns, and scaling considerations"
+owner: "@staff-engineer"
+dependencies:
+  - architecture.md
+---
+
+# Performance
+
+## Overview
+
+Docket is a single-user, local-first CLI tool backed by an embedded SQLite database. Its performance profile is that of a command-line utility: sub-second response times for typical workloads (hundreds to low thousands of issues), with no network latency, no connection overhead beyond process startup, and no concurrent-user contention. There are no explicit performance SLAs, benchmarks, or profiling infrastructure in the codebase today.
+
+## Database Configuration
+
+### SQLite Pragmas
+
+The database is opened in `internal/db/db.go:Open()` with three performance-relevant pragmas:
+
+| Pragma | Value | Effect |
+|--------|-------|--------|
+| `journal_mode` | `WAL` | Write-Ahead Logging enables concurrent readers with a single writer, reducing lock contention vs. the default rollback journal. |
+| `foreign_keys` | `ON` | Enforces referential integrity at the cost of additional constraint checks on every write. |
+| `busy_timeout` | `5000` | Waits up to 5 seconds for a locked database before returning `SQLITE_BUSY`, preventing immediate failures when the WAL writer is active. |
+
+### Connection Pool
+
+The pool is explicitly limited to **1 connection** (`SetMaxOpenConns(1)`). This is intentional: SQLite is single-writer, so a single connection avoids Go's `database/sql` pool from opening multiple connections that would contend on SQLite's file-level lock. The tradeoff is that all operations are serialized, including reads. For a single-user CLI this is appropriate; it would become a bottleneck under concurrent access (e.g., if docket were ever used as a library or server).
+
+## Schema Indexing
+
+The schema (`internal/db/schema.go`) defines the following indexes:
+
+### Issues Table Indexes
+- `idx_issues_status` on `issues(status)` -- used by default list filtering (excludes `done`)
+- `idx_issues_priority` on `issues(priority)` -- used by priority-based list filtering
+- `idx_issues_assignee` on `issues(assignee)` -- used by assignee filter
+- `idx_issues_parent_id` on `issues(parent_id)` -- used by parent/child queries, `RootsOnly` filter
+- `idx_issues_created_at` on `issues(created_at)` -- used by default sort order
+- `idx_issues_updated_at` on `issues(updated_at)` -- used by `updated_at` sort
+
+### Other Indexes
+- `idx_issue_files_file_path` on `issue_files(file_path)` -- supports file-path lookups
+- `idx_proposals_status` on `proposals(status)` -- proposal listing by status
+- `idx_proposals_created_at` on `proposals(created_at)` -- proposal ordering
+- `idx_votes_proposal_id` on `votes(proposal_id)` -- vote lookups by proposal
+
+Composite primary keys on `issue_labels(issue_id, label_id)`, `issue_files(issue_id, file_path)`, and `proposal_issues(proposal_id, issue_id)` also serve as indexes.
+
+**Gap:** There is no composite index for the default sort order (`status` rank, `priority` rank, `created_at`). The `CASE`-based ordering expressions in `ListIssues` cannot use indexes, so the default sort requires a full table scan followed by an in-memory sort. This is acceptable at current scale but would degrade with tens of thousands of issues.
+
+## Query Patterns
+
+### N+1 Query Avoidance
+
+The codebase has explicit batch-loading patterns to avoid N+1 queries:
+
+- **`HydrateLabels()`** (`internal/db/issues.go`): Bulk-loads all labels for a set of issues using a single `WHERE issue_id IN (...)` query. Called after `ListIssues`, `ListAllIssues`, and `GetIssuesByIDs`.
+- **`HydrateFiles()`** (`internal/db/files.go`): Same pattern for issue-file attachments.
+- **`GetBatchSubIssueProgress()`** (`internal/db/issues.go`): Batch-computes (done, total) counts for multiple parent IDs in a single recursive CTE query, avoiding per-parent queries.
+- **`GetIssuesByIDs()`** (`internal/db/issues.go`): Fetches multiple issues by ID in a single query with label and file hydration.
+
+### Recursive CTEs
+
+Several operations use SQLite recursive CTEs:
+
+- **`GetSubIssueTree()`**: Fetches the full recursive descendant tree of an issue.
+- **`GetSubIssueProgress()`** and **`GetBatchSubIssueProgress()`**: Compute progress aggregates over descendant trees.
+- **`IsDescendant()`**: Cycle detection for parent reparenting.
+- **`CascadeDeleteIssue()`**: Deletes an entire sub-tree in one operation.
+- **`checkCycleTx()`** (`internal/db/relations.go`): Cycle detection for `blocks`/`depends_on` relations using recursive reachability.
+
+These CTEs are unbounded -- they traverse as deep as the tree goes. For typical issue hierarchies (2-5 levels) this is negligible. Pathologically deep trees (hundreds of levels) would be slower, but this is an unlikely usage pattern.
+
+### ListIssues Query Complexity
+
+`ListIssues()` dynamically builds a query with optional `JOIN`, `WHERE`, `GROUP BY`, `HAVING`, and `ORDER BY` clauses. Key observations:
+
+- **Label filtering** adds a JOIN to `issue_labels` and `labels`, plus `GROUP BY i.id` and `HAVING COUNT(DISTINCT l.name) = N` for AND-logic. This is the most expensive filter combination.
+- A **count query** always runs before the main query to support pagination metadata, meaning every `ListIssues` call executes two queries against the database.
+- The default composite sort uses `CASE` expressions that cannot leverage indexes.
+
+### Export Path
+
+The `export` command (`internal/cli/export.go`) loads **all** data into memory in 6 separate queries (issues, comments, relations, labels, label-mappings, file-mappings), then applies in-memory filtering. This is fine for the expected scale (thousands of issues) but does not support streaming for very large datasets.
+
+### Import Path
+
+The `import` command (`internal/cli/import.go`) performs all inserts within a **single transaction**, which is good for both atomicity and performance (avoids per-statement fsync). The two-pass strategy for parent-child relationships (insert with NULL parent, then UPDATE parent_id) adds N extra UPDATE statements but avoids insertion-order dependency issues.
+
+## In-Memory Algorithms
+
+### DAG and Topological Sort (Planner)
+
+The planner (`internal/planner/`) operates entirely in-memory after loading all issues and relations:
+
+- **`BuildDAG()`**: O(N + E) where N = issues, E = relations. Constructs an adjacency representation using hash maps.
+- **`TopoSort()`**: Kahn's algorithm, O(N + E). Groups issues by topological level for phase planning.
+- **`GeneratePlan()`**: After topological sort, applies filtering (O(N)), sorting per phase (O(k log k) per phase), and file-collision splitting (O(k * f) where f = files per issue).
+- **`FindReady()`**: Linear scan over all DAG nodes, O(N).
+- **`scopeToDescendants()`**: BFS over parent-child tree, O(N).
+
+All planner operations build the full DAG in memory from all issues and all directional relations. There is no incremental or partial loading.
+
+### BFS Graph Traversal
+
+The `issue graph` command (`internal/cli/issue_graph.go`) performs BFS over precomputed adjacency lists. It has an optional `--depth` limit to bound traversal. Without a depth limit, it visits all reachable nodes, which scales with the graph's connected component size.
+
+## Caching
+
+There is minimal caching in the codebase:
+
+- **`DefaultAuthor()`** (`internal/config/config.go`): Uses `sync.Once` to cache the result of `git config user.name` for the process lifetime. This avoids repeated subprocess spawning (2-second timeout per invocation).
+
+There is no query result caching, prepared statement caching, or memoization layer. Each CLI invocation is a fresh process that opens the database, executes queries, and exits. Process-level caching would provide no benefit in this execution model.
+
+## Concurrency
+
+Docket is a **single-process, single-goroutine** CLI tool. There are:
+
+- No goroutines beyond the main goroutine
+- No `sync.Mutex` or `sync.RWMutex` usage (except `sync.Once` for author caching)
+- No `sync.Pool` usage
+- No channel-based concurrency
+- No parallel query execution
+
+The single-connection SQLite pool enforces serialization at the database level. All transaction boundaries use `db.Begin()` / `tx.Commit()` with `defer tx.Rollback()` for cleanup, which is correct but not optimized for throughput.
+
+## Pagination
+
+`ListIssues` supports `LIMIT` and `OFFSET` pagination via the `ListOptions` struct. The total count is computed separately for pagination metadata. There is no cursor-based pagination. OFFSET-based pagination degrades for large offsets (SQLite must scan and discard rows), but this is unlikely to be problematic at the expected scale.
+
+## Known Performance Gaps
+
+1. **No benchmarks**: The test suite (`make test`) contains no `Benchmark*` functions. There is no baseline for regression detection.
+
+2. **No prepared statements**: All queries are built as raw strings and executed directly. The `database/sql` driver may cache prepared statements internally, but the application does not explicitly prepare and reuse statements.
+
+3. **Full table loads for planner and export**: `ListAllIssues()` and `GetAllDirectionalRelations()` load entire tables into memory. This is acceptable at current scale but would not scale to hundreds of thousands of issues.
+
+4. **Double query for pagination**: Every `ListIssues` call runs a count query and a data query. These could potentially be combined using `COUNT(*) OVER()` window functions if SQLite's window function support is sufficient.
+
+5. **Default sort is index-unfriendly**: The `CASE`-based status/priority ranking in the default `ORDER BY` clause cannot use indexes, forcing a full sort on every list operation.
+
+6. **No WAL checkpoint management**: WAL mode is enabled but there is no explicit `PRAGMA wal_checkpoint` call. SQLite auto-checkpoints at the default threshold (1000 pages), which is fine for typical use but could cause occasional write stalls if the WAL grows large during bulk operations.
+
+7. **File-collision splitting is quadratic in worst case**: `splitByFileCollision()` in the planner iterates over remaining issues in each pass. If every issue collides with every other issue on file paths, this degrades to O(N^2). In practice, file collisions should be sparse.
+
+## Scaling Characteristics
+
+| Dimension | Current Approach | Expected Ceiling |
+|-----------|-----------------|-----------------|
+| Issue count | Full table loads for planner/export | Low thousands comfortable; tens of thousands would slow planner and export |
+| Relation count | Full relation loads for DAG construction | Proportional to issue count; same ceiling |
+| Tree depth | Unbounded recursive CTEs | Hundreds of levels would be slow; unlikely in practice |
+| Concurrent users | Single connection, single process | Not designed for concurrent access |
+| Database size | Single SQLite file, no compaction | Hundreds of MB before file I/O becomes noticeable |
+| CLI startup | Opens DB + runs pragmas + migrates on every invocation | Negligible for SQLite; would matter for network databases |
+
+## Recommendations for Future Work
+
+These are observations, not requirements. The current performance characteristics are appropriate for the tool's scope and maturity.
+
+1. **Add benchmark tests** for `ListIssues` (with various filter combinations), `BuildDAG` + `TopoSort`, and `HydrateLabels` at representative scales (100, 1000, 10000 issues). This establishes a regression baseline.
+2. **Consider `LIMIT` on recursive CTEs** for safety, especially `checkCycleTx()` which could theoretically traverse large graphs.
+3. **Profile before optimizing**: The tool is fast enough today. Any optimization work should be driven by measured bottlenecks, not speculation.

--- a/docs/spec/review-strategy.md
+++ b/docs/spec/review-strategy.md
@@ -1,0 +1,194 @@
+---
+project: "docket"
+maturity: "draft"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Review dimensions, quality gates, and review workflow for the docket project"
+owner: "@staff-engineer"
+dependencies:
+  - code-quality.md
+  - testing.md
+---
+
+# Review Strategy
+
+## 1. Overview
+
+Docket is a Go CLI project with a small codebase (~70 source files) and a solo/small-team contributor model. Reviews currently happen through GitHub pull requests, with CI as the primary automated quality gate. There are no formal CODEOWNERS, PR templates, or written review checklists. This spec documents what exists and identifies where review practices should be strengthened as the project grows.
+
+## 2. Current Review Workflow
+
+### 2.1 Pull Request Flow
+
+All changes merge to `main` via GitHub pull requests. Commit messages follow conventional commit format (`feat:`, `fix:`, `chore:`). PR titles mirror this convention with issue references (e.g., `feat: add docket vote subcommand for PBFT consensus voting (#5)`).
+
+There is no branch naming convention enforced, though feature branches are used in practice (e.g., `feature/watch`).
+
+### 2.2 CI as Automated Reviewer
+
+The CI pipeline (`.github/workflows/ci.yaml`) runs on every PR and push to `main`. It performs:
+
+- **Multi-platform build**: macOS (Intel + ARM) and Linux (x86_64 + ARM64) via Vorpal build system
+- **Artifact generation**: Cross-platform binary archives uploaded as artifacts
+
+**What CI does NOT do today:**
+
+- No `go test ./...` step in CI (tests exist but are only run locally via `make test`)
+- No `go vet` or `staticcheck` step in CI (available locally via `make lint`)
+- No QA suite (`scripts/qa.sh`) execution in CI
+- No code coverage measurement or thresholds
+- No dependency vulnerability scanning
+
+This is a significant gap: the CI pipeline validates that the binary builds across platforms but does not validate correctness or code quality.
+
+### 2.3 Manual Quality Gates
+
+Available locally but not enforced in CI:
+
+| Command | What It Checks |
+|---------|---------------|
+| `make test` | Unit tests (`go test ./...`) |
+| `make lint` | `go vet` + `staticcheck` (if installed) |
+| `make vet` | `go vet ./...` only |
+| `scripts/qa.sh` | Comprehensive end-to-end CLI test suite (29 sections, 150+ checks) |
+
+### 2.4 Human Review
+
+With 11 total commits and 3 merged PRs, the project is in early stages. PRs have been merged with squash commits. There is no evidence of formal reviewer assignment, required approvals, or branch protection rules enforcing reviews.
+
+## 3. Review Dimensions
+
+The following dimensions are weighted by their relevance to the docket project, given its nature as a local-first CLI tool backed by SQLite.
+
+### 3.1 High Priority
+
+**Data Integrity (Critical)**
+- SQLite schema changes require migration paths (`internal/db/schema.go` has versioned migrations up to v3)
+- Schema changes can silently corrupt or lose user data if migrations are wrong
+- The `ON DELETE SET NULL` and `ON DELETE CASCADE` behaviors in foreign keys are correctness-critical
+- Review must verify: migration idempotency, rollback safety, data preservation across versions
+
+**JSON API Contract Stability (Critical)**
+- Every command supports `--json` with a documented envelope (`{"ok": true, "data": ..., "message": ...}`)
+- AI agents depend on stable JSON shapes — breaking changes silently break agent workflows
+- Error codes (`GENERAL_ERROR`, `NOT_FOUND`, `VALIDATION_ERROR`, `CONFLICT`) are part of the contract
+- The QA suite has dedicated sections (Q, R) for contract and exit code validation
+- Review must verify: no field renames/removals without versioning, exit codes match documented behavior
+
+**CLI UX Consistency (High)**
+- One-file-per-command pattern in `internal/cli/` must be maintained
+- All commands must support `--json` and `--quiet` flags via `getWriter()`
+- Interactive forms (via `charmbracelet/huh`) must degrade gracefully in non-TTY contexts
+- Review must verify: new commands follow established patterns, help text is consistent
+
+### 3.2 Medium Priority
+
+**Dependency Graph Correctness (Medium-High)**
+- The DAG builder (`internal/planner/`) powers `docket next` and `docket plan`
+- Cycle detection, topological sort, and phase planning must remain correct
+- Bugs here cause agents to get stuck or execute work in wrong order
+- Review must verify: edge cases (cycles, orphans, deep trees) are covered
+
+**Error Handling (Medium)**
+- `CmdError` wrapping with `output.ErrorCode` ensures machine-readable errors
+- Review must verify: errors propagate correctly, appropriate error codes are used, no silent failures
+
+**Security at System Boundaries (Medium)**
+- SQL injection via user-supplied issue titles, labels, comments, file paths
+- Path traversal in file attachment commands (`docket issue file add`)
+- Review must verify: parameterized queries used (they are, via `database/sql`), file paths validated
+
+### 3.3 Lower Priority (for this project)
+
+**Performance** — Local SQLite with small datasets; not a current concern unless someone loads thousands of issues.
+
+**Concurrency** — Single-user CLI; SQLite handles serialization. No goroutine-safety concerns in current architecture.
+
+**Accessibility** — Terminal rendering via lipgloss; `--json` mode is the accessibility escape hatch for non-visual consumers.
+
+## 4. Review Checklist
+
+For use during code review of PRs to the docket project.
+
+### Must-Check (Blockers)
+
+- [ ] Schema changes include a versioned migration in `schema.go` with `currentSchemaVersion` incremented
+- [ ] JSON output shapes are backward-compatible (no removed/renamed fields)
+- [ ] Exit codes match documented behavior (0 success, 1 general error, 2 not found, 3 validation, 4 conflict)
+- [ ] New commands follow the one-file-per-command pattern and register with parent command
+- [ ] New commands support `--json` via `getWriter()` and use `output.Writer.Success()`/`Error()`
+- [ ] SQL queries use parameterized statements (no string interpolation)
+- [ ] QA tests added or updated in `scripts/qa/` for new commands/flags
+
+### Should-Check (Concerns)
+
+- [ ] Model types have correct `MarshalJSON`/`UnmarshalJSON` implementations
+- [ ] Activity log entries created for state-changing operations
+- [ ] Error messages are user-friendly in human mode and machine-parseable in JSON mode
+- [ ] Cobra command metadata (Use, Short, Long, Example) is complete
+- [ ] Interactive forms have non-interactive fallbacks for CI/agent contexts
+
+### Nice-to-Check (Suggestions)
+
+- [ ] Rendering changes tested in narrow terminal widths
+- [ ] Import/export round-trip preserved for affected data
+- [ ] `make lint` passes without new warnings
+
+## 5. High-Risk Areas
+
+These areas of the codebase warrant extra scrutiny during review:
+
+| Area | Risk | Why |
+|------|------|-----|
+| `internal/db/schema.go` | Data loss | Migrations are irreversible in practice; wrong migration = corrupted databases |
+| `internal/db/issues.go` | Data integrity | Core CRUD operations, complex filtering, parent-child relationships |
+| `internal/db/relations.go` | Graph integrity | Dependency links that power the planner; wrong links = wrong execution order |
+| `internal/planner/` | Correctness | DAG/topological sort — subtle bugs cause silent wrong behavior |
+| `internal/output/` | API contract | Any change here affects every consumer of `--json` output |
+| `internal/model/` (JSON methods) | API contract | Marshal/Unmarshal changes break agent integrations silently |
+
+## 6. Gaps and Recommendations
+
+### 6.1 Critical Gaps
+
+**No automated testing in CI.** The CI pipeline only validates that binaries compile across platforms. Neither `go test`, `go vet`, `staticcheck`, nor the QA suite runs in CI. This means PRs can merge with broken tests, lint violations, or functional regressions.
+
+**Recommendation:** Add a `test` job to `ci.yaml` that runs `make test`, `make lint`, and `scripts/qa.sh` before the build job. This is the single highest-leverage improvement to review quality.
+
+**No branch protection rules.** There is no evidence of required reviews, required status checks, or restrictions on force-pushing to `main`.
+
+**Recommendation:** Enable branch protection on `main` requiring at least one approval and passing CI checks.
+
+### 6.2 Moderate Gaps
+
+**No PR template.** Contributors (human or AI) have no guidance on what to include in a PR description.
+
+**Recommendation:** Add `.github/PULL_REQUEST_TEMPLATE.md` covering: what changed, why, testing performed, and a checklist derived from Section 4 above.
+
+**No CODEOWNERS file.** As the team grows, there is no mechanism to auto-assign reviewers for high-risk areas (db/, planner/, output/).
+
+**No contribution guidelines.** The README has a "Contributing" section with development setup and coding guidelines, but it is minimal. The one-file-per-command and `--json` requirements are documented there, which is good.
+
+### 6.3 Positive Practices Already in Place
+
+- Conventional commit messages are consistently used
+- The QA suite (`scripts/qa.sh`) is comprehensive with 29 test sections covering every command
+- JSON contract validation exists as dedicated QA sections (Q: JSON contracts, R: exit codes)
+- The `output.Writer` abstraction enforces consistent JSON envelopes across all commands
+- Domain types use custom JSON marshaling, centralizing serialization concerns
+- `CmdError` with error codes provides structured error handling throughout
+
+## 7. Review Process for AI Agent Changes
+
+Docket is designed for AI agent integration, and AI agents (via Claude Code) also contribute to its development. Special review considerations for agent-generated changes:
+
+- **Verify intent matches TDD:** Agent implementations should trace back to approved TDDs in `docs/tdd/`
+- **Check for over-engineering:** Agents may add unnecessary abstractions, error handling for impossible cases, or unused parameters
+- **Validate QA coverage:** Ensure agents add QA test sections for new functionality, not just unit tests
+- **Review commit granularity:** Agent-generated PRs may bundle too many changes or split them unnaturally
+
+## 8. Vote-Based Consensus Review
+
+The `docket vote` subsystem (added in commit `0c4077b`) provides a PBFT-inspired consensus mechanism for reviewing technical decisions. This is used by the `/vote` Claude Code skill to validate TDDs and architectural decisions before implementation begins. Vote proposals can be linked to docket issues via `docket vote link`, creating traceability between decisions and work items.
+
+This mechanism supplements but does not replace human code review for implementation PRs.

--- a/docs/spec/security.md
+++ b/docs/spec/security.md
@@ -1,0 +1,199 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Security posture, trust boundaries, input validation, and data protection for the docket CLI"
+owner: "@staff-engineer"
+dependencies:
+  - architecture.md
+---
+
+# Security Specification
+
+## 1. Overview
+
+Docket is a local-first CLI issue tracker that stores all data in a local SQLite database (`.docket/issues.db`). It has no network-facing components, no authentication/authorization system, no remote API, and no secret management. The security posture is shaped by its single-user, local-only design.
+
+## 2. Threat Model
+
+### 2.1 Trust Boundaries
+
+Docket operates within a single trust boundary: the local user's filesystem and terminal session. There are no network boundaries, remote services, or multi-user access controls.
+
+| Boundary | Description |
+|---|---|
+| **Filesystem** | The `.docket/` directory and its `issues.db` file are readable/writable by the local user. No access controls beyond standard POSIX file permissions. |
+| **CLI Input** | All user input arrives via command-line flags, arguments, stdin pipes, or interactive terminal forms (via charmbracelet/huh). |
+| **Environment Variables** | `DOCKET_PATH` (database location), `EDITOR` (external editor for comments), `TERM` (terminal capability detection). |
+| **External Processes** | The `$EDITOR` program is invoked for interactive comment editing. `git config user.name` is invoked to resolve the default author name. |
+
+### 2.2 Attack Surface
+
+The attack surface is minimal due to the local-only architecture:
+
+- **No network listeners**: Docket does not bind sockets, serve HTTP, or accept remote connections.
+- **No authentication**: There is no user authentication or session management. The tool trusts the local user entirely.
+- **No secrets**: Docket does not handle API keys, tokens, passwords, or any form of credentials.
+- **No encryption**: The SQLite database is stored in plaintext. There is no at-rest or in-transit encryption.
+
+### 2.3 Residual Risks
+
+| Risk | Severity | Description |
+|---|---|---|
+| Malicious import file | Low | A crafted JSON import file could inject unexpected data into the database. Mitigated by validation (see Section 4). |
+| EDITOR command injection | Low | `$EDITOR` is passed directly to `exec.Command()`, which does not invoke a shell. This is safe against shell injection but the user-specified editor binary itself could be malicious. This is standard CLI behavior (git, etc. do the same). |
+| Symlink attacks on temp files | Low | `os.CreateTemp()` is used for editor temp files. Go's implementation uses `O_EXCL` which prevents symlink attacks. |
+| Database path traversal via DOCKET_PATH | Low | `DOCKET_PATH` is used as-is without sanitization. A malicious env variable could point to an arbitrary filesystem location. This is by design (trusted local environment). |
+
+## 3. SQL Injection Protection
+
+Docket constructs SQL queries using a combination of parameterized queries and allowlist-validated dynamic SQL. The approach is well-implemented overall.
+
+### 3.1 Parameterized Queries
+
+The vast majority of queries use Go's `database/sql` parameter placeholders (`?`). All user-supplied values (titles, descriptions, status values, assignees, etc.) are passed as parameters, never interpolated into SQL strings. Examples:
+
+- `internal/db/issues.go`: `CreateIssue`, `GetIssue`, `UpdateIssue` -- all use `?` placeholders for values.
+- `internal/db/proposals.go`: `CreateProposal` -- uses `?` placeholders for all 14 columns.
+- `internal/db/comments.go`, `internal/db/labels.go`, etc. -- consistent parameterized query usage.
+
+### 3.2 Dynamic SQL Construction (Allowlisted)
+
+Three cases construct SQL with `fmt.Sprintf`, all with appropriate safeguards:
+
+1. **Sort field in `ListIssues`** (`internal/db/issues.go:308-320`): The sort field is validated against both `validSortFields` (a string allowlist) and `safeIdentifier` (a regex `^[a-z_]+$`) before interpolation. The sort direction is forced to either `"ASC"` or `"DESC"`. This is defense-in-depth.
+
+2. **`IN (?)` placeholders** (`makePlaceholders` at `internal/db/issues.go:837`): Generates `?, ?, ...` strings for parameterized `IN` clauses. The placeholder count is derived from `len(slice)`, not user input. Values are passed as parameters.
+
+3. **`countByColumn`** (`internal/db/issues.go:922-940`): Column names are interpolated via `fmt.Sprintf` but this function is only called with hardcoded string literals (`"status"`, `"priority"`) from `CountByStatus` and `CountByPriority`. There is no path for user input to reach the column parameter.
+
+4. **`ClearAllData`** (`internal/db/issues.go:955-978`): Table names are from a hardcoded string slice. No user input flows into the `DELETE FROM` statements.
+
+### 3.3 Update Field Validation
+
+`UpdateIssue` (`internal/db/issues.go:399-468`) accepts a `map[string]interface{}` of field names to values. Field names are validated against `validUpdateFields` before being interpolated into the `SET` clause. Values are passed as `?` parameters. This is correctly implemented.
+
+## 4. Input Validation
+
+### 4.1 Enum Validation
+
+All enum-typed fields are validated before database insertion:
+
+- **Status**: Validated by `model.ValidateStatus()` against `validStatuses` (`backlog`, `todo`, `in-progress`, `review`, `done`).
+- **Priority**: Validated by `model.ValidatePriority()` against `validPriorities` (`critical`, `high`, `medium`, `low`, `none`).
+- **Issue Kind**: Validated by `model.ValidateIssueKind()` against `validIssueKinds` (`bug`, `feature`, `task`, `epic`, `chore`).
+- **Criticality**: Validated by `model.ValidateCriticality()` for proposals.
+- **Verdict**: Validated by `model.ValidateVerdict()` for votes.
+- **Relation Type**: Validated by `model.ValidateRelationType()` for issue relations.
+
+Validation occurs at both the CLI layer (before calling db functions) and during JSON deserialization (via `UnmarshalJSON`).
+
+### 4.2 ID Parsing
+
+Issue IDs are parsed by `model.ParseID()` which accepts both `"DKT-5"` and `"5"` formats, validates the result is a positive integer, and rejects all other input.
+
+### 4.3 Import Validation
+
+The `import` command (`internal/cli/import.go`) validates imported JSON data before any database mutations:
+
+- Version field must equal `1`.
+- All issue status, priority, and kind fields are re-validated.
+- All relation types are validated.
+- The import is performed within a single transaction -- if any step fails, all changes are rolled back.
+- Destructive `--replace` mode requires interactive confirmation (unless in `--json` mode).
+
+### 4.4 Stdin Input Limits
+
+Both `issue create` (description from stdin) and `comment add` (body from stdin) enforce a 1 MiB size limit via `io.LimitReader`. This prevents unbounded memory allocation from malicious pipe input.
+
+### 4.5 Gaps
+
+- **Free-text fields**: Title, description, comment body, assignee, label names, and file paths accept arbitrary strings with no length limits beyond the stdin cap. There is no maximum length enforced at the database layer.
+- **File path values**: The `issue file add` command stores file paths as opaque strings in the database. It does not verify the path exists, is within a project boundary, or is a safe path. This is by design (metadata tracking, not file access).
+
+## 5. External Process Execution
+
+### 5.1 Editor Invocation
+
+`internal/cli/issue_comment.go:74-96` invokes `$EDITOR` (or `vi` as fallback) for interactive comment editing:
+
+```
+editorCmd := exec.Command(editor, tmpPath)
+```
+
+This is safe against shell injection because `exec.Command` does not invoke a shell -- it executes the binary directly with the temp file path as a single argument. The temp file uses `os.CreateTemp` with a `docket-comment-*.md` pattern and is cleaned up via `defer os.Remove`.
+
+### 5.2 Git Config Resolution
+
+`internal/config/config.go:80-88` resolves the default author via:
+
+```
+exec.CommandContext(ctx, "git", "config", "user.name")
+```
+
+This is safe: the command and all arguments are hardcoded string literals. A 2-second timeout prevents hanging if git is misconfigured. Falls back to `user.Current().Username`, then `"unknown"`.
+
+## 6. Database Security
+
+### 6.1 SQLite Configuration
+
+The database connection (`internal/db/db.go:12-36`) is configured with:
+
+- **WAL mode**: `PRAGMA journal_mode=WAL` -- provides crash recovery.
+- **Foreign keys**: `PRAGMA foreign_keys=ON` -- enforces referential integrity.
+- **Busy timeout**: `PRAGMA busy_timeout=5000` -- prevents immediate lock failures.
+- **Single connection**: `db.SetMaxOpenConns(1)` -- prevents concurrent write contention.
+
+### 6.2 Schema Migration
+
+Migrations (`internal/db/schema.go`) run within transactions. Each migration atomically updates both the schema and the version number. There is self-healing logic for databases that were incorrectly stamped as v2 without the proposals table (lines 223-231).
+
+### 6.3 No Encryption
+
+The SQLite database file is stored as plaintext. There is no SQLCipher or equivalent encryption. Data protection relies entirely on filesystem permissions. The `.docket/` directory is created with mode `0755` (`internal/cli/init.go:64`).
+
+## 7. Build and Distribution Security
+
+### 7.1 Build Configuration
+
+- **CGO_ENABLED=0**: The binary is compiled as a static Go binary with no C dependencies (via Makefile and Vorpal build config). This eliminates a class of memory safety issues.
+- **Version embedding**: Build version, commit hash, and date are injected via `-ldflags` at build time.
+- **Static analysis**: `staticcheck` and `go vet` are configured as lint targets.
+
+### 7.2 Install Script
+
+`scripts/install.sh` downloads pre-built binaries from GitHub releases over HTTPS. Notable security characteristics:
+
+- Uses `set -eu` for fail-fast behavior.
+- Downloads are over HTTPS from `github.com` releases.
+- Uses a temporary directory cleaned up via `trap`.
+- **Gap**: No checksum verification of downloaded archives. No GPG signature verification. The integrity of the downloaded binary depends entirely on HTTPS transport security and GitHub's release infrastructure.
+
+### 7.3 Dependencies
+
+The project has 39 direct and indirect Go module dependencies (per `go.sum`). Key security-relevant dependencies:
+
+| Dependency | Purpose | Notes |
+|---|---|---|
+| `modernc.org/sqlite` | Pure-Go SQLite | No CGO required; avoids C memory safety issues |
+| `github.com/microcosm-cc/bluemonday` | HTML sanitization | Used by glamour for Markdown rendering output |
+| `github.com/spf13/cobra` | CLI framework | Well-maintained, widely used |
+| `google.golang.org/grpc` | gRPC (indirect, via Vorpal SDK) | Not used at runtime by docket itself |
+
+## 8. Data Privacy
+
+- All data is stored locally. No telemetry, analytics, or remote data collection exists.
+- The `export` command can write all database content to JSON, CSV, or Markdown files. The user controls where these files are written.
+- The default author is resolved from `git config user.name` or the OS username. This is the only PII-adjacent data collected, and it stays local.
+
+## 9. Security Gaps and Recommendations
+
+| Gap | Severity | Recommendation |
+|---|---|---|
+| No checksum verification in install script | Medium | Add SHA-256 checksum verification for downloaded release archives. |
+| `.docket/` directory created with 0755 | Low | Consider 0700 for the directory to prevent other users on multi-user systems from reading the database. |
+| No database file permission enforcement | Low | Verify or set file permissions on `issues.db` after creation (e.g., 0600). |
+| No input length limits on free-text fields | Low | Consider adding reasonable length limits for title, description, assignee, and label fields at the CLI or database layer to prevent accidental abuse. |
+| Markdown export does not sanitize for all contexts | Low | The `escapeMarkdown` function handles common Markdown special characters but may not cover all edge cases for downstream consumption. |
+| No dependency vulnerability scanning in CI | Medium | Add `govulncheck` or equivalent to the build/lint pipeline. |

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -1,0 +1,201 @@
+---
+project: "docket"
+maturity: "experimental"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Testing strategy, tooling, and coverage across unit and end-to-end test layers"
+owner: "@staff-engineer"
+dependencies:
+  - code-quality.md
+---
+
+# Testing Specification
+
+## Overview
+
+Docket employs a two-tier testing strategy: **Go unit/integration tests** (`go test ./...`) for
+internal package logic, and a **shell-based QA suite** (`scripts/qa/`) for end-to-end CLI
+validation. There is no separate integration test tier (e.g., against a real on-disk database)
+beyond what the unit tests achieve with in-memory SQLite. There is no CI pipeline configured in the
+repository -- all tests are run locally via `make test` or by executing the QA scripts directly.
+
+## Test Pyramid
+
+| Layer | Count | Location | Runner |
+|---|---|---|---|
+| Unit / integration (Go) | ~205 test functions | `internal/**/*_test.go` (5 packages) | `go test ./...` / `make test` |
+| End-to-end (shell) | 29 scripts, ~600 assertions | `scripts/qa/test_*.sh` | Bash, sourcing `scripts/qa/helpers.sh` |
+| CI | None | N/A | N/A |
+
+The pyramid is bottom-heavy in raw test count but the QA suite provides significant breadth
+across every CLI command, exercising the full binary as a black-box.
+
+## Unit / Integration Tests (Go)
+
+### Packages With Tests
+
+| Package | Test Functions | What Is Tested |
+|---|---|---|
+| `internal/db` | ~97 | Database open/config (WAL, FK, busy_timeout), schema initialization, idempotency, migrations, CRUD for issues/relations/files/proposals/votes, cascade deletes, unique constraints, cycle detection, activity log recording, export/import |
+| `internal/model` | ~42 | ID formatting/parsing round-trips, enum validation (status, priority, kind, criticality, verdict), color/icon methods, JSON serialization round-trips for Issue/Comment/Proposal/Vote/Findings, backward compatibility with v2 JSON |
+| `internal/output` | ~23 | JSON envelope marshaling (success/error), Writer modes (JSON/human/quiet), exit code mapping, NO_COLOR/TERM environment handling, multi-line vs single-line output formatting |
+| `internal/render` | ~36 | Board rendering (plain-text and color paths), column ordering, title truncation, priority indicators, sub-issue progress bars, overflow indicators, grouped table rendering with parent-child relationships, empty states |
+| `internal/planner` | ~7 | `splitByFileCollision` algorithm: empty input, no files, no conflicts, all-shared-file, mixed conflicts, multi-file collisions |
+
+### Packages Without Tests
+
+| Package | Notes |
+|---|---|
+| `cmd/docket` | CLI command wiring -- covered indirectly by QA shell suite |
+| `cmd/vorpal` | Vorpal integration entry point -- no tests |
+| `internal/cli` | CLI framework / command registration -- covered indirectly by QA shell suite |
+| `internal/config` | Configuration loading -- partially covered by QA tests (sections A, C, D) |
+| `internal/filter` | Issue filtering logic -- covered indirectly by QA list/board tests |
+
+### Test Patterns and Conventions
+
+- **In-memory SQLite**: All `internal/db` tests use `:memory:` databases via a `mustOpen(t)`
+  helper. This avoids filesystem side effects and enables parallel execution but means WAL mode
+  behavior is not fully exercised (in-memory reports `journal_mode = memory`).
+- **Standard library only**: Tests use `testing.T` exclusively -- no third-party assertion
+  libraries (testify, gomega, etc.) or mocking frameworks.
+- **Table-driven tests**: Used extensively in `internal/model` (ParseID, validation) and
+  `internal/db` (cycle detection). Subtests via `t.Run()` are used for cycle detection scenarios.
+- **Test helpers**: `mustOpen`, `mustCreateIssue`, `mustCreateRelation`, `createTestIssue`,
+  `makeIssue`, `makeTestIssue` provide DRY setup. Helpers call `t.Helper()` for correct line
+  reporting.
+- **Cleanup via `t.Cleanup`**: Database connections are closed automatically.
+- **Environment manipulation**: `t.Setenv("NO_COLOR", "1")` is used in render/output tests to
+  get deterministic plain-text output.
+- **No mocking**: Tests exercise real production code paths. Database tests hit real (in-memory)
+  SQLite. No mock interfaces or test doubles are used anywhere.
+- **No test fixtures or golden files**: Expected values are inline in test functions.
+- **No benchmarks**: No `Benchmark*` functions exist in the codebase.
+- **No fuzz tests**: No `Fuzz*` functions exist in the codebase.
+
+### Test Execution
+
+```sh
+make test       # runs: go test ./...
+go vet ./...    # run via: make vet (also a prereq of make lint)
+```
+
+No test flags (race detector, coverage, timeout) are configured by default in the Makefile.
+
+## End-to-End QA Suite (Shell)
+
+### Structure
+
+The QA suite lives in `scripts/qa/` and consists of:
+
+- **`helpers.sh`**: Shared test infrastructure providing:
+  - `setup()` / `cleanup()`: Creates/destroys temp directories, sets `DOCKET_PATH`
+  - `run()` / `run_env()` / `run_stdin()`: Command runners that capture stdout, stderr, exit code
+  - `assert_exit()`, `assert_json()`, `assert_json_exists()`, `assert_json_null()`,
+    `assert_json_array_min()`, `assert_json_array_max()`, `assert_json_all()`: Assertion functions
+  - `assert_stdout_contains()`, `assert_stderr_contains()`: Output content assertions
+  - `extract_id()`: Extracts numeric ID from JSON `data.id` field
+  - `check()`: Records PASS/FAIL results with counters
+
+- **29 test scripts** (`test_a_no_db.sh` through `test_zc_export_import.sh`): Alphabetically
+  ordered, each testing a specific feature area. Scripts are designed to run sequentially as
+  some depend on state created by earlier scripts.
+
+### Coverage by Section
+
+| Script | Area | Key Scenarios |
+|---|---|---|
+| `test_a` | No-DB commands | version, help, config without initialized DB |
+| `test_b` | Init | Database initialization |
+| `test_c` | Config | Configuration display |
+| `test_d` | Path override | `DOCKET_PATH` env var |
+| `test_e` | Quiet mode | Suppressed output |
+| `test_f` | Create | Issue creation with all field combinations, validation errors |
+| `test_g` | List | Issue listing, filtering |
+| `test_h` | Show | Issue detail view |
+| `test_i` | Move | Status transitions |
+| `test_j` | Close | Closing issues |
+| `test_k` | Reopen | Reopening issues |
+| `test_l` | Edit | Field editing |
+| `test_m` | Edit reparent | Parent-child reparenting, cycle prevention |
+| `test_n` | Delete simple | Simple deletion |
+| `test_o` | Delete cascade | Cascade and orphan deletion modes |
+| `test_p` | Activity | Activity log entries |
+| `test_q` | JSON contracts | Validates JSON response schema for every command |
+| `test_r` | Exit codes | Validates exit code conventions (0/2/3/4) across commands |
+| `test_s` | Error paths | Error handling for missing DB, invalid inputs |
+| `test_t` | Comment | Single comment operations |
+| `test_u` | Comments | Comment listing |
+| `test_v` | Label | Label management |
+| `test_w` | Link | Issue relations / linking |
+| `test_x` | Next | Next-up issue suggestion |
+| `test_y` | Plan | Execution plan generation |
+| `test_z` | Graph | Dependency graph |
+| `test_za` | Stats | Statistics command |
+| `test_zb` | Board | Board view |
+| `test_zc` | Export/Import | Data export and import |
+
+### QA Execution Model
+
+- Scripts are pure Bash, requiring `jq` for JSON assertions
+- Each script defines a single function (e.g., `test_f_create()`) that is called by a runner
+- Tests operate against a fresh temp directory per suite run
+- Tests are stateful and ordered -- later scripts may depend on issues created by earlier ones
+- No parallelism -- scripts run sequentially
+
+## Gaps and Honest Assessment
+
+### No CI Pipeline
+
+There is no `.github/workflows/`, `.gitlab-ci.yml`, or equivalent. Tests are run manually.
+This means there is no automated gate preventing regressions from being merged.
+
+### No Coverage Tracking
+
+No coverage tool is configured. There is no coverage report, no coverage threshold, and no
+visibility into which code paths are exercised. Running `go test -cover ./...` would produce
+coverage data but this is not part of the standard workflow.
+
+### No Race Detector
+
+`go test -race` is not configured in the Makefile or run by default. Given that docket is a
+CLI tool (not a server), race conditions are unlikely but not impossible in concurrent database
+access scenarios.
+
+### Missing Unit Tests for CLI/Config/Filter Packages
+
+Five packages (`cmd/docket`, `cmd/vorpal`, `internal/cli`, `internal/config`, `internal/filter`)
+have zero Go unit tests. The `cmd/` and `internal/cli` packages are partially covered by the
+QA shell suite, but `internal/filter` logic is only tested indirectly through CLI commands.
+
+### No Benchmarks or Fuzz Tests
+
+There are no performance benchmarks or fuzz tests. For a CLI tool this is reasonable, but the
+`internal/db` layer (especially list queries with complex sorting) could benefit from benchmarks
+as issue counts grow.
+
+### QA Suite Is Stateful
+
+The shell QA suite's sequential, stateful nature means individual test scripts cannot be run
+in isolation (later scripts depend on database state from earlier ones). This makes debugging
+failures harder and prevents parallelization.
+
+### In-Memory vs On-Disk SQLite
+
+All Go database tests use `:memory:` SQLite databases. This is fast and side-effect-free but
+does not exercise WAL mode, file locking, or disk I/O behaviors that occur in production. The
+QA shell suite partially fills this gap by running the real binary against temp-dir databases.
+
+## Test Utilities Summary
+
+| Utility | Location | Purpose |
+|---|---|---|
+| `mustOpen(t)` | `internal/db/db_test.go` | Opens in-memory DB, registers cleanup |
+| `mustCreateIssue(t, db, title)` | `internal/db/relations_test.go` | Creates minimal issue |
+| `mustCreateRelation(t, db, s, t, rt)` | `internal/db/relations_test.go` | Creates relation |
+| `createTestIssue(t, db, ...)` | `internal/db/issues_test.go` | Creates issue with status/priority |
+| `createTestIssueWithParent(...)` | `internal/db/issues_test.go` | Creates child issue |
+| `makeIssue(id, title, ...)` | `internal/render/board_test.go` | Creates minimal model.Issue |
+| `makeTestIssue(...)` | `internal/render/table_test.go` | Creates model.Issue with kind/parent |
+| `intPtr(i)` | `internal/render/table_test.go` | Helper for *int values |
+| `helpers.sh` | `scripts/qa/helpers.sh` | Full QA test infrastructure |

--- a/docs/tdd/watch-feature.md
+++ b/docs/tdd/watch-feature.md
@@ -1,0 +1,494 @@
+---
+project: "docket"
+maturity: "approved"
+last_updated: "2026-03-21"
+updated_by: "@staff-engineer"
+scope: "Add --watch flag to all read subcommands for polling-based real-time refresh"
+owner: "@staff-engineer"
+dependencies:
+  - ../spec/architecture.md
+---
+
+# TDD: Watch Mode for Read Subcommands
+
+## 1. Problem Statement
+
+Docket is increasingly used in AI-driven workflows where agents create, move, and close issues
+autonomously. Humans observing these workflows currently have to manually re-run commands
+(`docket board`, `docket issue list`, etc.) to see changes. This creates a poor feedback loop
+for human oversight of AI agents.
+
+**Goal:** Add a `--watch` flag to all read subcommands that enables polling-based real-time
+refresh. The terminal output is cleared and reprinted on a configurable interval, giving humans
+a live dashboard view of AI-driven changes.
+
+**Constraints:**
+- No TUI framework (no bubbletea, no curses). Simple terminal clear + reprint.
+- No websocket or event streaming. Polling only.
+- Must work with `--json` mode (for piping to other tools).
+- Must work in non-TTY environments (CI, piped output) with graceful degradation.
+- Single DB connection reused across poll cycles (not reopened each time).
+
+**Acceptance Criteria:**
+1. `--watch` flag is available on all read subcommands (see Section 4 for the full list).
+2. `--interval` flag controls polling frequency (default: 2s, minimum: 500ms).
+3. Human mode: screen clears and reprints output each cycle. A subtle status line shows
+   the last refresh timestamp and interval.
+4. JSON mode with `--watch`: emits one complete JSON envelope per cycle, separated by newlines
+   (NDJSON). Each object is a self-contained response identical to a non-watch invocation.
+5. Ctrl+C cleanly exits the watch loop with no partial output or dangling goroutines.
+6. `--quiet` mode suppresses the watch status line but still refreshes output.
+7. `--watch` without a TTY (piped stdout) skips ANSI clear sequences and just prints
+   successive outputs separated by a blank line.
+8. The DB connection opened in `PersistentPreRunE` is reused for all poll cycles.
+9. Existing non-watch behavior is completely unchanged.
+10. `--watch` on a write command (e.g., `issue create`) produces a validation error.
+
+## 2. Context & Prior Art
+
+### Existing Patterns in Docket
+
+- **Global flags** are registered on `rootCmd.PersistentFlags()` in `root.go:init()`:
+  `--json` and `--quiet`. Both are read via `cmd.Flags().GetBool()` in command handlers and
+  the `getWriter()` helper.
+- **DB lifecycle** is managed in `PersistentPreRunE` (open + migrate) and
+  `PersistentPostRunE` (close). The `*sql.DB` is stored in the command context. Commands
+  retrieve it via `getDB(cmd)`.
+- **Output dispatch** goes through `output.Writer.Success(data, message)`. JSON mode wraps
+  data in `{"ok": true, "data": ..., "message": "..."}`. Human mode prints the message string.
+- **All read commands** follow the same pattern: get writer, get DB, query, render, call
+  `w.Success()`.
+
+### How Other CLIs Do Watch
+
+- **`kubectl get --watch`**: Uses server-side watch streams (event-based). Falls back to
+  polling for resources that don't support watch. Outputs incremental updates.
+- **`watch(1)` (coreutils)**: External wrapper. Runs any command on an interval. Uses
+  ANSI clear (`\033[H\033[2J`). Shows header with interval and command.
+- **`docker stats`**: Continuous streaming mode. ANSI clear for TTY, plain append for non-TTY.
+- **`gh run watch`**: Polls GitHub API on an interval. Clears and reprints. Exits when the
+  run completes.
+
+Docket's approach most closely resembles `watch(1)` — a polling loop with terminal clear. The
+key difference is that it lives inside the CLI rather than being an external wrapper, which
+allows it to reuse the DB connection and integrate with `--json` mode.
+
+## 3. Alternatives Considered
+
+### Alternative A: External `watch` wrapper (Rejected)
+
+Users could run `watch -n 2 docket board`. This works but:
+- Reopens the DB on every invocation (migration check, pragma setup).
+- Cannot emit NDJSON (each run is independent).
+- No `--json` integration.
+- Platform-dependent (`watch` is not available on macOS by default).
+- Status: **Rejected** — too many limitations for the primary use case.
+
+### Alternative B: Per-command `--watch` flag (Rejected)
+
+Each command registers its own `--watch` flag and implements its own loop. This would work but:
+- Duplicates loop logic across 12+ commands.
+- Inconsistent behavior risk.
+- Higher maintenance burden.
+- Status: **Rejected** — violates DRY.
+
+### Alternative C: Persistent flag on root + shared watch utility (Recommended)
+
+Register `--watch` and `--interval` as persistent flags on `rootCmd`. Add a shared utility
+package (`internal/watch`) that wraps the command's `RunE` in a polling loop. Each command
+opts in by being listed in a watch-eligible registry. Write commands are excluded via
+validation in `PersistentPreRunE`.
+
+- Centralized loop logic.
+- Consistent behavior across all read commands.
+- Easy to add new commands to the watch-eligible list.
+- Status: **Recommended**.
+
+### Alternative D: Middleware/decorator pattern on RunE (Considered)
+
+Instead of a shared utility, wrap each command's `RunE` function with a decorator at
+registration time. The decorator checks `--watch` and either runs once or enters the loop.
+
+This is functionally equivalent to Alternative C but couples the watch logic to command
+registration rather than command execution. It's slightly more magical but eliminates the
+need for commands to explicitly call a watch helper.
+
+- Status: **Viable alternative**. The recommended approach (C) is preferred for explicitness,
+  but this could be adopted if the team prefers less boilerplate in command handlers.
+
+## 4. Architecture & System Design
+
+### 4.1 Watch-Eligible Commands
+
+All read/query commands that display data and do not mutate state:
+
+| Command | Parent | Notes |
+|---------|--------|-------|
+| `board` | root | Kanban board view |
+| `issue list` | issue | Issue listing |
+| `issue show <id>` | issue | Single issue detail |
+| `issue log <id>` | issue | Activity history |
+| `issue graph <id>` | issue | Dependency graph |
+| `issue comment list <id>` | issue comment | Comment listing |
+| `next` | root | Work-ready issues |
+| `plan` | root | Execution plan |
+| `stats` | root | Summary statistics |
+| `vote list` | vote | Proposal listing |
+| `vote show <id>` | vote | Proposal detail |
+| `vote result <id>` | vote | Consensus result |
+| `config` | root | Configuration display (borderline — config rarely changes, but including it is harmless and consistent) |
+
+**Excluded commands** (write/mutate operations):
+`init`, `issue create`, `issue edit`, `issue close`, `issue reopen`, `issue delete`,
+`issue move`, `issue comment add`, `issue label`, `issue link`, `issue file`,
+`import`, `export`, `vote create`, `vote cast`, `vote commit`, `vote link`, `vote unlink`,
+`version`.
+
+### 4.2 Component Layout
+
+```
+internal/
+  watch/
+    watch.go          -- RunWatch loop, signal handling, terminal clear
+  cli/
+    root.go           -- Register --watch, --interval persistent flags
+                      -- PersistentPreRunE: validate --watch not on write commands
+    watch_commands.go  -- watchEligible set (command names -> bool)
+```
+
+### 4.3 Flag Registration
+
+In `root.go:init()`, alongside existing persistent flags:
+
+```go
+rootCmd.PersistentFlags().BoolP("watch", "w", false, "Watch for changes and refresh output")
+rootCmd.PersistentFlags().Duration("interval", 2*time.Second, "Refresh interval for --watch")
+```
+
+`-w` as the shorthand is available (no current flag uses it).
+
+### 4.4 Watch Validation
+
+In `PersistentPreRunE`, after config/DB setup, if `--watch` is set:
+
+1. Check that the current command is in the watch-eligible set. If not, return a
+   `CmdError` with `ErrValidation`: `"--watch is not supported on write commands"`.
+2. Validate `--interval` is >= 500ms. Return `ErrValidation` if not.
+
+**Flag visibility:** Since `--watch` and `--interval` are persistent flags on `rootCmd`,
+they appear in `--help` output for all commands — including write commands where they are
+invalid. To avoid confusion, use Cobra's `MarkHidden` to hide these flags on ineligible
+commands. In `watch_commands.go`, during `init()`, iterate over all registered commands
+and call `cmd.Flags().MarkHidden("watch")` and `cmd.Flags().MarkHidden("interval")` for
+commands not in the watch-eligible set. This keeps the flags functional (for validation
+error reporting) but removes them from help output where they don't apply.
+
+### 4.5 Watch Loop Architecture
+
+The `internal/watch` package exposes a single function:
+
+```go
+// RunWatch executes fn repeatedly on the given interval until ctx is cancelled.
+// It handles terminal clearing, output buffering, and newline separation.
+// On each cycle, RunWatch creates a fresh bytes.Buffer, wraps it in an
+// output.Writer, and passes it to fn. After fn returns, RunWatch clears the
+// screen (if TTY) and flushes the buffer to real stdout atomically.
+func RunWatch(ctx context.Context, opts Options, fn func(ctx context.Context, w *output.Writer) error) error
+
+type Options struct {
+    Interval  time.Duration
+    JSONMode  bool
+    QuietMode bool
+    IsTTY     bool       // whether stdout is a terminal
+    Stdout    io.Writer  // real stdout destination (typically os.Stdout)
+    Stderr    io.Writer  // real stderr destination (typically os.Stderr)
+}
+```
+
+**Loop behavior:**
+
+1. Create a `bytes.Buffer` for output capture.
+2. Create an `output.Writer` with `Stdout` set to the buffer.
+3. Call `fn(ctx, w)` — the command logic writes to the buffer via the Writer.
+4. **First cycle**: Write buffer contents directly to real `Stdout`.
+5. **Subsequent cycles**:
+   - **Human mode + TTY**: Write ANSI escape `\033[H\033[2J` (cursor home + clear screen)
+     to real stdout, then print a status line (`Watching every Xs... (last update: HH:MM:SS)`),
+     then flush the buffer atomically.
+   - **Human mode + non-TTY**: Print a blank line separator, then flush the buffer.
+   - **JSON mode**: Flush the buffer directly. Each cycle emits one JSON envelope via
+     `w.Success()`, which already writes a newline. No additional separator needed. The
+     result is NDJSON.
+   - **Quiet mode**: Suppress the status line but still clear and reprint.
+6. Reset the buffer for the next cycle.
+7. Wait for `interval` using `time.NewTicker`.
+8. On `ctx.Done()` (from signal handler), return `nil`.
+
+The buffer is allocated once and reused (`buf.Reset()`) across cycles to avoid allocation
+churn.
+
+**Signal handling:**
+
+The caller (command handler) sets up signal handling:
+
+```go
+ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+```
+
+This is passed to `RunWatch`. When the user presses Ctrl+C, the context is cancelled,
+the ticker stops, and the function returns cleanly.
+
+### 4.6 Command Integration Pattern
+
+Each watch-eligible command modifies its `RunE` to check for watch mode. The extracted
+command logic functions accept an `*output.Writer` parameter rather than calling
+`getWriter(cmd)` internally. This allows `RunWatch` to inject a buffer-backed Writer on
+each cycle, and lets the non-watch path use the standard Writer from `getWriter(cmd)`.
+
+The pattern is:
+
+```go
+// runBoard contains the actual query + render + output logic.
+// It accepts a Writer so the caller controls where output goes.
+func runBoard(cmd *cobra.Command, args []string, w *output.Writer) error {
+    conn := getDB(cmd)
+    // ... query, render, w.Success(result, message)
+    return nil
+}
+
+var boardCmd = &cobra.Command{
+    RunE: func(cmd *cobra.Command, args []string) error {
+        watchMode, _ := cmd.Flags().GetBool("watch")
+        if watchMode {
+            interval, _ := cmd.Flags().GetDuration("interval")
+            jsonMode, _ := cmd.Flags().GetBool("json")
+            quietMode, _ := cmd.Flags().GetBool("quiet")
+            ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+            defer stop()
+            return watch.RunWatch(ctx, watch.Options{
+                Interval:  interval,
+                JSONMode:  jsonMode,
+                QuietMode: quietMode,
+                IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+                Stdout:    os.Stdout,
+                Stderr:    os.Stderr,
+            }, func(ctx context.Context, w *output.Writer) error {
+                return runBoard(cmd, args, w)
+            })
+        }
+        return runBoard(cmd, args, getWriter(cmd))
+    },
+}
+```
+
+Key points:
+- `runBoard` (and all extracted `runXxx` functions) accept `*output.Writer` as a parameter.
+- In watch mode, `RunWatch` creates a buffer-backed Writer and passes it to `fn` each cycle.
+- In non-watch mode, the standard `getWriter(cmd)` is passed directly.
+- `getDB(cmd)` is still called inside `runXxx` — the DB connection is stable across cycles
+  (see Section 4.7).
+
+### 4.7 DB Connection Reuse
+
+The existing `PersistentPreRunE` opens the DB once and stores it in the command context.
+`PersistentPostRunE` closes it. Since `RunWatch` runs within `RunE` (between pre and post
+hooks), the same `*sql.DB` connection is reused for all poll cycles. No changes to the
+DB lifecycle are needed.
+
+SQLite WAL mode with `busy_timeout=5000` ensures that the watching process can read even
+while another process (e.g., an AI agent) is writing. This is the intended concurrency model.
+
+**Single-connection constraint:** The DB is opened with `MaxOpenConns(1)`. This is correct
+for the watch loop because polling is sequential — each cycle runs a query, waits for the
+result, renders, then sleeps. There is no concurrent goroutine access within the watch
+process. Implementers must not introduce concurrent DB access within the watch loop (e.g.,
+parallel queries across goroutines) as this would deadlock on the single-connection pool.
+If future work requires concurrent queries within a cycle, `MaxOpenConns` would need to
+be increased, but that is out of scope for this feature.
+
+### 4.8 Output Buffering
+
+To avoid partial screen renders (flickering), `RunWatch` owns the output buffer and
+performs atomic writes. The sequence on each cycle is:
+
+1. `RunWatch` creates an `output.Writer` with `Stdout` pointing to a `bytes.Buffer`.
+2. `fn(ctx, w)` runs the command logic, which writes to the buffer via the Writer.
+3. After `fn` returns, `RunWatch` clears the screen (if TTY + human mode), writes the
+   status line, then flushes the entire buffer to real stdout in a single `Write` call.
+
+This ensures the user never sees a partially rendered frame. The clear + write happens
+as a single atomic sequence from the terminal's perspective.
+
+The `output.Writer` struct already accepts an `io.Writer` for `Stdout`, so no changes to
+the `output` package are needed — `RunWatch` simply constructs a Writer with the buffer
+as its `Stdout` field each cycle.
+
+The `bytes.Buffer` is allocated once and reused via `buf.Reset()` across cycles to avoid
+per-cycle allocation overhead.
+
+### 4.9 Terminal Width Changes
+
+The existing render layer (`internal/render`) already queries terminal width dynamically
+(e.g., `render.TerminalWidth()` for board column layout). Since this is called on each
+render cycle, terminal resize during watch mode is handled automatically.
+
+## 5. Data Models & Storage
+
+No data model or storage changes. Watch mode is purely a presentation-layer feature.
+
+## 6. API Contracts
+
+### CLI Interface
+
+```
+# Watch the board, refresh every 2s (default)
+docket board --watch
+
+# Watch with custom interval
+docket board --watch --interval 5s
+
+# Watch in JSON mode (produces NDJSON)
+docket board --watch --json
+
+# Watch issue list with filters
+docket issue list --watch --status in-progress --label backend
+
+# Watch a specific issue
+docket issue show DKT-5 --watch
+
+# Watch the execution plan
+docket plan --watch
+
+# Invalid: watch on a write command
+docket issue create --watch  # Error: --watch is not supported on write commands
+```
+
+### NDJSON Output (--watch --json)
+
+Each line is a complete, self-contained JSON envelope:
+
+```json
+{"ok":true,"data":{"columns":[...]},"message":""}
+{"ok":true,"data":{"columns":[...]},"message":""}
+{"ok":true,"data":{"columns":[...]},"message":""}
+```
+
+Consumers can process each line independently with `jq`, `jaq`, or any JSON streaming parser.
+
+### Human Output
+
+```
+Watching every 2s... (last update: 14:32:05) [Ctrl+C to exit]
+
+[normal board/list/detail output here]
+```
+
+The status line appears at the top. On non-TTY, the status line is omitted and outputs are
+separated by blank lines.
+
+## 7. Migration & Rollout
+
+No database migration. No breaking changes. The feature is purely additive:
+
+- `--watch` defaults to `false` — existing behavior is unchanged.
+- `--interval` is only meaningful when `--watch` is set.
+- No existing flags conflict with `-w` shorthand.
+
+**Rollout:** Ship in a single release. No feature flag needed. The feature is opt-in
+via `--watch`.
+
+## 8. Risks & Open Questions
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Flickering on slow renders | Low | Output buffering (Section 4.8) eliminates partial renders |
+| DB lock contention with concurrent writer | Low | WAL mode + `busy_timeout=5000` handles this. Read-only queries don't block writers |
+| Accidental watch on write command | Low | Explicit validation in `PersistentPreRunE` prevents this |
+| Memory growth on long watch sessions | Low | Each cycle overwrites the buffer; no accumulation. `bytes.Buffer` is reused |
+| ANSI clear doesn't work in all terminals | Low | Degrade to newline separation for non-TTY. The `\033[H\033[2J` sequence works in all modern terminals (iTerm2, Terminal.app, Windows Terminal, xterm, alacritty) |
+
+### Open Questions
+
+1. **Should `export` support `--watch`?** Export writes to a file or stdout in a specific
+   format (JSON/CSV/Markdown). Watching an export seems unusual but not harmful. Current
+   decision: **exclude** — export is conceptually a snapshot operation, not a live view.
+   Revisit if users request it.
+
+2. **Should `config` support `--watch`?** Config rarely changes during a session. Including
+   it is harmless for consistency but of questionable utility. Current decision: **include**
+   for consistency, since it is a read-only command.
+
+3. **Should the status line include a cycle counter?** e.g., `Watching every 2s... (refresh #42,
+   last update: 14:32:05)`. Useful for debugging but adds noise. Current decision: **omit**
+   the counter. Add it later if debugging watch behavior becomes a need.
+
+## 9. Testing Strategy
+
+### Unit Tests
+
+- `internal/watch/watch_test.go`:
+  - Test that `RunWatch` calls `fn` immediately on first cycle.
+  - Test that `RunWatch` calls `fn` again after interval.
+  - Test that `RunWatch` returns cleanly when context is cancelled.
+  - Test that TTY mode emits ANSI clear before each cycle (after first).
+  - Test that non-TTY mode emits blank line separators.
+  - Test that JSON mode does not emit ANSI sequences.
+  - Test that quiet mode suppresses the status line.
+  - Test that interval < 500ms is rejected at validation.
+
+### Integration Tests (in `internal/cli/`)
+
+- Test that `--watch` flag is accepted on all watch-eligible commands.
+- Test that `--watch` on a write command returns `ErrValidation`.
+- Test that `--watch` with `--json` produces valid NDJSON (multiple JSON objects parseable
+  independently).
+
+### Manual Testing
+
+- Run `docket board --watch` in a TTY terminal. Verify smooth clear and reprint.
+- In a second terminal, create/move/close issues. Verify the board updates.
+- Run `docket board --watch --json | head -3` and verify 3 valid JSON lines.
+- Pipe `docket board --watch` to `cat` (non-TTY). Verify no ANSI codes in output.
+- Press Ctrl+C during watch. Verify clean exit (no stack trace, no partial output).
+- Test with `--interval 500ms` and `--interval 100ms` (should reject).
+
+## 10. Observability & Operational Readiness
+
+Watch mode is a client-side presentation feature with no server component. Observability
+is limited to the CLI itself:
+
+- **Exit code**: 0 on clean Ctrl+C exit. Non-zero on errors (same as existing error handling).
+- **Stderr diagnostics**: Errors during a watch cycle are printed to stderr (same as existing
+  error handling). The watch loop continues unless the error is unrecoverable (DB connection
+  lost).
+- **Error recovery in watch loop**: If a single cycle's `fn` returns an error, print the error
+  to stderr and continue watching (do not exit). This handles transient DB busy errors. If
+  the error persists for 3 consecutive cycles, exit with the error.
+
+## 11. Implementation Phases
+
+### Phase 1: Watch utility package (Size: S)
+
+- Create `internal/watch/watch.go` with `RunWatch` function.
+- Implement terminal clear (ANSI), TTY detection, output buffering, signal handling.
+- Unit tests for `RunWatch`.
+- No command integration yet.
+
+### Phase 2: Flag registration and validation (Size: S)
+
+- Add `--watch` and `--interval` persistent flags to `rootCmd` in `root.go`.
+- Create `watch_commands.go` with the watch-eligible command set.
+- Add validation in `PersistentPreRunE`.
+- Unit test for validation (watch on write command -> error).
+
+### Phase 3: Integrate watch into read commands (Size: M)
+
+- Extract command logic into named functions for each watch-eligible command.
+- Add the `if watchMode { RunWatch(...) }` pattern to each command's `RunE`.
+- Integration tests.
+
+**Dependencies:** Phase 3 depends on Phase 1 and Phase 2. Phases 1 and 2 are independent
+and can be done in parallel.

--- a/internal/cli/board.go
+++ b/internal/cli/board.go
@@ -1,12 +1,19 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -26,94 +33,115 @@ var boardCmd = &cobra.Command{
 	Use:   "board",
 	Short: "Show Kanban board",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		labels, _ := cmd.Flags().GetStringSlice("label")
-		priorities, _ := cmd.Flags().GetStringSlice("priority")
-		assignee, _ := cmd.Flags().GetString("assignee")
-		expand, _ := cmd.Flags().GetBool("expand")
-
-		// Validate filter enum values.
-		for _, p := range priorities {
-			if err := model.ValidatePriority(model.Priority(p)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runBoard(cmd, args, w)
+			})
 		}
-
-		opts := db.ListOptions{
-			Priorities:  priorities,
-			Labels:      labels,
-			Assignee:    assignee,
-			IncludeDone: true,
-		}
-
-		issues, _, err := db.ListIssues(conn, opts)
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
-		}
-
-		// By default, roll up sub-issues into their parent (exclude issues that
-		// have a parent). When --expand is set, show all issues individually.
-		if !expand {
-			var roots []*model.Issue
-			for _, issue := range issues {
-				if issue.ParentID == nil {
-					roots = append(roots, issue)
-				}
-			}
-			issues = roots
-		}
-
-		if w.JSONMode {
-			// Group issues by status for structured output.
-			groups := make(map[model.Status][]*model.Issue)
-			for _, issue := range issues {
-				groups[issue.Status] = append(groups[issue.Status], issue)
-			}
-
-			var columns []boardColumn
-			for _, status := range render.StatusOrder {
-				col := groups[status]
-				if col == nil {
-					col = []*model.Issue{}
-				}
-				columns = append(columns, boardColumn{
-					Status: string(status),
-					Count:  len(col),
-					Issues: col,
-				})
-			}
-
-			w.Success(boardResult{Columns: columns}, "")
-			return nil
-		}
-
-		// Build sub-issue progress map for parent issues in a single query.
-		parentIDs := make([]int, len(issues))
-		for i, issue := range issues {
-			parentIDs[i] = issue.ID
-		}
-		batchProgress, err := db.GetBatchSubIssueProgress(conn, parentIDs)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching sub-issue progress: %w", err), output.ErrGeneral)
-		}
-		progress := make(map[int]render.SubIssueProgress, len(batchProgress))
-		for id, counts := range batchProgress {
-			if counts[1] > 0 {
-				progress[id] = render.SubIssueProgress{Done: counts[0], Total: counts[1]}
-			}
-		}
-
-		boardOpts := render.BoardOptions{
-			Expand:   expand,
-			Progress: progress,
-		}
-		message := render.RenderBoard(issues, boardOpts)
-		w.Success(nil, message)
-
-		return nil
+		return runBoard(cmd, args, getWriter(cmd))
 	},
+}
+
+func runBoard(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	labels, _ := cmd.Flags().GetStringSlice("label")
+	priorities, _ := cmd.Flags().GetStringSlice("priority")
+	assignee, _ := cmd.Flags().GetString("assignee")
+	expand, _ := cmd.Flags().GetBool("expand")
+
+	// Validate filter enum values.
+	for _, p := range priorities {
+		if err := model.ValidatePriority(model.Priority(p)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+
+	opts := db.ListOptions{
+		Priorities:  priorities,
+		Labels:      labels,
+		Assignee:    assignee,
+		IncludeDone: true,
+	}
+
+	issues, _, err := db.ListIssues(conn, opts)
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
+	}
+
+	// By default, roll up sub-issues into their parent (exclude issues that
+	// have a parent). When --expand is set, show all issues individually.
+	if !expand {
+		var roots []*model.Issue
+		for _, issue := range issues {
+			if issue.ParentID == nil {
+				roots = append(roots, issue)
+			}
+		}
+		issues = roots
+	}
+
+	if w.JSONMode {
+		// Group issues by status for structured output.
+		groups := make(map[model.Status][]*model.Issue)
+		for _, issue := range issues {
+			groups[issue.Status] = append(groups[issue.Status], issue)
+		}
+
+		var columns []boardColumn
+		for _, status := range render.StatusOrder {
+			col := groups[status]
+			if col == nil {
+				col = []*model.Issue{}
+			}
+			columns = append(columns, boardColumn{
+				Status: string(status),
+				Count:  len(col),
+				Issues: col,
+			})
+		}
+
+		w.Success(boardResult{Columns: columns}, "")
+		return nil
+	}
+
+	// Build sub-issue progress map for parent issues in a single query.
+	parentIDs := make([]int, len(issues))
+	for i, issue := range issues {
+		parentIDs[i] = issue.ID
+	}
+	batchProgress, err := db.GetBatchSubIssueProgress(conn, parentIDs)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching sub-issue progress: %w", err), output.ErrGeneral)
+	}
+	progress := make(map[int]render.SubIssueProgress, len(batchProgress))
+	for id, counts := range batchProgress {
+		if counts[1] > 0 {
+			progress[id] = render.SubIssueProgress{Done: counts[0], Total: counts[1]}
+		}
+	}
+
+	boardOpts := render.BoardOptions{
+		Expand:   expand,
+		Progress: progress,
+	}
+	message := render.RenderBoard(issues, boardOpts)
+	w.Success(nil, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -10,6 +15,7 @@ import (
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -27,63 +33,84 @@ var configCmd = &cobra.Command{
 	Short:       "Display docket configuration",
 	Annotations: map[string]string{"skipDB": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		cfg := getCfg(cmd)
-
-		docketPathEnv := os.Getenv("DOCKET_PATH")
-
-		exists, err := cfg.Exists()
-		if err != nil {
-			return cmdErr(fmt.Errorf("checking database: %w", err), output.ErrGeneral)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runConfig(cmd, args, w)
+			})
 		}
+		return runConfig(cmd, args, getWriter(cmd))
+	},
+}
 
-		if !exists {
-			w.Warn("No docket database found. Run 'docket init' to create one.")
+func runConfig(cmd *cobra.Command, args []string, w *output.Writer) error {
+	cfg := getCfg(cmd)
 
-			info := configInfo{
-				DBPath:        cfg.DBPath,
-				DBSizeBytes:   0,
-				SchemaVersion: 0,
-				IssuePrefix:   model.IDPrefix,
-				DocketPathEnv: docketPathEnv,
-				DocketPathSet: cfg.EnvVarSet,
-			}
+	docketPathEnv := os.Getenv("DOCKET_PATH")
 
-			w.Success(info, formatConfigHuman(info, true))
+	exists, err := cfg.Exists()
+	if err != nil {
+		return cmdErr(fmt.Errorf("checking database: %w", err), output.ErrGeneral)
+	}
 
-			return nil
-		}
-
-		conn, err := db.Open(cfg.DBPath)
-		if err != nil {
-			return cmdErr(fmt.Errorf("opening database: %w", err), output.ErrGeneral)
-		}
-		defer conn.Close()
-
-		schemaVersion, err := db.SchemaVersion(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("reading schema version: %w", err), output.ErrGeneral)
-		}
-
-		stat, err := os.Stat(cfg.DBPath)
-		if err != nil {
-			return cmdErr(fmt.Errorf("reading database file: %w", err), output.ErrGeneral)
-		}
-		dbSize := stat.Size()
+	if !exists {
+		w.Warn("No docket database found. Run 'docket init' to create one.")
 
 		info := configInfo{
 			DBPath:        cfg.DBPath,
-			DBSizeBytes:   dbSize,
-			SchemaVersion: schemaVersion,
+			DBSizeBytes:   0,
+			SchemaVersion: 0,
 			IssuePrefix:   model.IDPrefix,
 			DocketPathEnv: docketPathEnv,
 			DocketPathSet: cfg.EnvVarSet,
 		}
 
-		w.Success(info, formatConfigHuman(info, false))
+		w.Success(info, formatConfigHuman(info, true))
 
 		return nil
-	},
+	}
+
+	conn, err := db.Open(cfg.DBPath)
+	if err != nil {
+		return cmdErr(fmt.Errorf("opening database: %w", err), output.ErrGeneral)
+	}
+	defer conn.Close()
+
+	schemaVersion, err := db.SchemaVersion(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("reading schema version: %w", err), output.ErrGeneral)
+	}
+
+	stat, err := os.Stat(cfg.DBPath)
+	if err != nil {
+		return cmdErr(fmt.Errorf("reading database file: %w", err), output.ErrGeneral)
+	}
+	dbSize := stat.Size()
+
+	info := configInfo{
+		DBPath:        cfg.DBPath,
+		DBSizeBytes:   dbSize,
+		SchemaVersion: schemaVersion,
+		IssuePrefix:   model.IDPrefix,
+		DocketPathEnv: docketPathEnv,
+		DocketPathSet: cfg.EnvVarSet,
+	}
+
+	w.Success(info, formatConfigHuman(info, false))
+
+	return nil
 }
 
 func formatSize(bytes int64) string {

--- a/internal/cli/issue_comment_list.go
+++ b/internal/cli/issue_comment_list.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var commentListCmd = &cobra.Command{
@@ -16,47 +22,66 @@ var commentListCmd = &cobra.Command{
 	Short: "List comments on an issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		id, err := model.ParseID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runIssueCommentList(cmd, args, w)
+			})
 		}
-
-		// Verify the issue exists.
-		if _, err := db.GetIssue(conn, id); err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
-		}
-
-		comments, err := db.ListComments(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching comments: %w", err), output.ErrGeneral)
-		}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		if jsonMode {
-			w.Success(comments, "")
-			return nil
-		}
-
-		if len(comments) == 0 {
-			quiet, _ := cmd.Flags().GetBool("quiet")
-			msg := render.EmptyState(
-				fmt.Sprintf("No comments on %s", model.FormatID(id)),
-				fmt.Sprintf("Add one with: docket issue comment add %s -m \"...\"", model.FormatID(id)),
-				quiet,
-			)
-			w.Success(nil, msg)
-			return nil
-		}
-
-		w.Success(comments, render.RenderCommentList(comments))
-		return nil
+		return runIssueCommentList(cmd, args, getWriter(cmd))
 	},
+}
+
+func runIssueCommentList(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	id, err := model.ParseID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+	}
+
+	// Verify the issue exists.
+	if _, err := db.GetIssue(conn, id); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
+	}
+
+	comments, err := db.ListComments(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching comments: %w", err), output.ErrGeneral)
+	}
+
+	if w.JSONMode {
+		w.Success(comments, "")
+		return nil
+	}
+
+	if len(comments) == 0 {
+		msg := render.EmptyState(
+			fmt.Sprintf("No comments on %s", model.FormatID(id)),
+			fmt.Sprintf("Add one with: docket issue comment add %s -m \"...\"", model.FormatID(id)),
+			w.QuietMode,
+		)
+		w.Success(nil, msg)
+		return nil
+	}
+
+	w.Success(comments, render.RenderCommentList(comments))
+	return nil
 }
 
 func init() {

--- a/internal/cli/issue_graph.go
+++ b/internal/cli/issue_graph.go
@@ -1,18 +1,24 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/planner"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/tree"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // graphNode represents an issue in the dependency graph.
@@ -41,100 +47,119 @@ var graphCmd = &cobra.Command{
 	Short: "Show dependency graph for an issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		id, err := model.ParseID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
-		}
-
-		issue, err := db.GetIssue(conn, id)
-		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
-		}
-
-		direction, _ := cmd.Flags().GetString("direction")
-		if direction != "up" && direction != "down" && direction != "both" {
-			return cmdErr(fmt.Errorf("invalid direction %q: must be one of [up, down, both]", direction), output.ErrValidation)
-		}
-
-		depth, _ := cmd.Flags().GetInt("depth")
-		if depth < 0 {
-			return cmdErr(fmt.Errorf("depth must be non-negative"), output.ErrValidation)
-		}
-
-		// Fetch all directional relations for graph traversal.
-		allRelations, err := db.GetAllDirectionalRelations(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
-		}
-
-		// Build adjacency lists from relations.
-		forward, backward := planner.BuildAdjacency(allRelations)
-
-		// BFS to collect reachable nodes.
-		visited := map[int]bool{id: true}
-		var edges []graphEdge
-
-		// maxDepth: 0 means unlimited.
-		maxDepth := depth
-
-		if direction == "down" || direction == "both" {
-			bfsGraph(id, forward, visited, &edges, "blocks", maxDepth)
-		}
-
-		if direction == "up" || direction == "both" {
-			bfsGraph(id, backward, visited, &edges, "blocked_by", maxDepth)
-		}
-
-		// Bulk-fetch issue details for all visited nodes.
-		visitedIDs := make([]int, 0, len(visited))
-		for nodeID := range visited {
-			visitedIDs = append(visitedIDs, nodeID)
-		}
-		issueMap, err := db.GetIssuesByIDs(conn, visitedIDs)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching issues: %w", err), output.ErrGeneral)
-		}
-		// Ensure the focal issue is in the map (it was already fetched above).
-		issueMap[id] = issue
-
-		// Build nodes list.
-		nodes := make([]graphNode, 0, len(issueMap))
-		for _, iss := range issueMap {
-			nodes = append(nodes, graphNode{
-				ID:     model.FormatID(iss.ID),
-				Title:  iss.Title,
-				Status: string(iss.Status),
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runIssueGraph(cmd, args, w)
 			})
 		}
-
-		result := graphResult{
-			IssueID: id,
-			Nodes:   nodes,
-			Edges:   edges,
-		}
-
-		mermaidMode, _ := cmd.Flags().GetBool("mermaid")
-		jsonMode, _ := cmd.Flags().GetBool("json")
-
-		if jsonMode {
-			w.Success(result, "")
-			return nil
-		}
-
-		if mermaidMode {
-			w.Success(result, renderMermaid(issueMap, edges))
-			return nil
-		}
-
-		w.Success(result, renderGraphTree(id, issueMap, forward, backward, direction, maxDepth))
-		return nil
+		return runIssueGraph(cmd, args, getWriter(cmd))
 	},
+}
+
+func runIssueGraph(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	id, err := model.ParseID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+	}
+
+	issue, err := db.GetIssue(conn, id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
+	}
+
+	direction, _ := cmd.Flags().GetString("direction")
+	if direction != "up" && direction != "down" && direction != "both" {
+		return cmdErr(fmt.Errorf("invalid direction %q: must be one of [up, down, both]", direction), output.ErrValidation)
+	}
+
+	depth, _ := cmd.Flags().GetInt("depth")
+	if depth < 0 {
+		return cmdErr(fmt.Errorf("depth must be non-negative"), output.ErrValidation)
+	}
+
+	// Fetch all directional relations for graph traversal.
+	allRelations, err := db.GetAllDirectionalRelations(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
+	}
+
+	// Build adjacency lists from relations.
+	forward, backward := planner.BuildAdjacency(allRelations)
+
+	// BFS to collect reachable nodes.
+	visited := map[int]bool{id: true}
+	var edges []graphEdge
+
+	// maxDepth: 0 means unlimited.
+	maxDepth := depth
+
+	if direction == "down" || direction == "both" {
+		bfsGraph(id, forward, visited, &edges, "blocks", maxDepth)
+	}
+
+	if direction == "up" || direction == "both" {
+		bfsGraph(id, backward, visited, &edges, "blocked_by", maxDepth)
+	}
+
+	// Bulk-fetch issue details for all visited nodes.
+	visitedIDs := make([]int, 0, len(visited))
+	for nodeID := range visited {
+		visitedIDs = append(visitedIDs, nodeID)
+	}
+	issueMap, err := db.GetIssuesByIDs(conn, visitedIDs)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching issues: %w", err), output.ErrGeneral)
+	}
+	// Ensure the focal issue is in the map (it was already fetched above).
+	issueMap[id] = issue
+
+	// Build nodes list.
+	nodes := make([]graphNode, 0, len(issueMap))
+	for _, iss := range issueMap {
+		nodes = append(nodes, graphNode{
+			ID:     model.FormatID(iss.ID),
+			Title:  iss.Title,
+			Status: string(iss.Status),
+		})
+	}
+
+	result := graphResult{
+		IssueID: id,
+		Nodes:   nodes,
+		Edges:   edges,
+	}
+
+	mermaidMode, _ := cmd.Flags().GetBool("mermaid")
+	if w.JSONMode {
+		w.Success(result, "")
+		return nil
+	}
+
+	if mermaidMode {
+		w.Success(result, renderMermaid(issueMap, edges))
+		return nil
+	}
+
+	w.Success(result, renderGraphTree(id, issueMap, forward, backward, direction, maxDepth))
+	return nil
 }
 
 // bfsGraph performs BFS from the start node, following the given adjacency list,

--- a/internal/cli/issue_list.go
+++ b/internal/cli/issue_list.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type listResult struct {
@@ -21,160 +27,179 @@ var listCmd = &cobra.Command{
 	Short:   "List issues",
 	Aliases: []string{"ls"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		statuses, _ := cmd.Flags().GetStringSlice("status")
-		priorities, _ := cmd.Flags().GetStringSlice("priority")
-		labels, _ := cmd.Flags().GetStringSlice("label")
-		types, _ := cmd.Flags().GetStringSlice("type")
-		assignee, _ := cmd.Flags().GetString("assignee")
-		parent, _ := cmd.Flags().GetString("parent")
-		rootsOnly, _ := cmd.Flags().GetBool("roots")
-		treeMode, _ := cmd.Flags().GetBool("tree")
-		sortFlag, _ := cmd.Flags().GetString("sort")
-		limit, _ := cmd.Flags().GetInt("limit")
-		all, _ := cmd.Flags().GetBool("all")
-
-		// Validate filter enum values.
-		for _, s := range statuses {
-			if err := model.ValidateStatus(model.Status(s)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runIssueList(cmd, args, w)
+			})
 		}
-		for _, p := range priorities {
-			if err := model.ValidatePriority(model.Priority(p)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
-		}
-		for _, t := range types {
-			if err := model.ValidateIssueKind(model.IssueKind(t)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
-		}
-
-		opts := db.ListOptions{
-			Statuses:    statuses,
-			Priorities:  priorities,
-			Labels:      labels,
-			Types:       types,
-			Assignee:    assignee,
-			RootsOnly:   rootsOnly,
-			IncludeDone: all,
-			Limit:       limit,
-		}
-
-		// Parse --parent flag.
-		if parent != "" {
-			pid, err := model.ParseID(parent)
-			if err != nil {
-				return cmdErr(fmt.Errorf("invalid parent ID: %w", err), output.ErrValidation)
-			}
-			opts.ParentID = &pid
-		}
-
-		// Parse --sort flag (field:direction).
-		if sortFlag != "" {
-			parts := strings.SplitN(sortFlag, ":", 2)
-			opts.Sort = parts[0]
-			if len(parts) > 1 {
-				opts.SortDir = parts[1]
-			}
-		}
-
-		issues, total, err := db.ListIssues(conn, opts)
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
-		}
-
-		result := listResult{Issues: issues, Total: total}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-
-		// Fetch parent issues and sub-issue progress for the grouped display.
-		// Only needed for human-readable output (JSON stays flat).
-		var parentMap map[int]*model.Issue
-		var progress map[int]render.SubIssueProgress
-		if !jsonMode {
-			// Build a set of issue IDs in the result set for quick lookup.
-			resultIDs := make(map[int]struct{}, len(issues))
-			for _, issue := range issues {
-				resultIDs[issue.ID] = struct{}{}
-			}
-
-			// Collect parent IDs that are referenced but not in the result set.
-			missingParentIDs := make(map[int]struct{})
-			for _, issue := range issues {
-				if issue.ParentID != nil {
-					pid := *issue.ParentID
-					if _, inResult := resultIDs[pid]; !inResult {
-						missingParentIDs[pid] = struct{}{}
-					}
-				}
-			}
-
-			// Batch-fetch missing parents if any exist.
-			if len(missingParentIDs) > 0 {
-				ids := make([]int, 0, len(missingParentIDs))
-				for id := range missingParentIDs {
-					ids = append(ids, id)
-				}
-				parentMap, err = db.GetIssuesByIDs(conn, ids)
-				if err != nil {
-					return cmdErr(fmt.Errorf("fetching parent issues: %w", err), output.ErrGeneral)
-				}
-			}
-
-			// Collect IDs of all parent issues that have children in the
-			// result set. This includes parents fetched into parentMap
-			// (excluded by filters) and parents already in the result set.
-			parentIDSet := make(map[int]struct{})
-			for id := range parentMap {
-				parentIDSet[id] = struct{}{}
-			}
-			for _, issue := range issues {
-				if issue.ParentID != nil {
-					pid := *issue.ParentID
-					if _, inResult := resultIDs[pid]; inResult {
-						parentIDSet[pid] = struct{}{}
-					} else if _, inMap := parentMap[pid]; inMap {
-						parentIDSet[pid] = struct{}{}
-					}
-				}
-			}
-
-			// Fetch sub-issue progress (done/total counts) for parent
-			// issues in a single batch query.
-			if len(parentIDSet) > 0 {
-				parentIDs := make([]int, 0, len(parentIDSet))
-				for id := range parentIDSet {
-					parentIDs = append(parentIDs, id)
-				}
-				batchProgress, err := db.GetBatchSubIssueProgress(conn, parentIDs)
-				if err != nil {
-					return cmdErr(fmt.Errorf("fetching sub-issue progress: %w", err), output.ErrGeneral)
-				}
-				progress = make(map[int]render.SubIssueProgress, len(batchProgress))
-				for id, counts := range batchProgress {
-					if counts[1] > 0 {
-						progress[id] = render.SubIssueProgress{Done: counts[0], Total: counts[1]}
-					}
-				}
-			}
-		}
-
-		var message string
-		if !jsonMode {
-			if treeMode {
-				message = render.RenderTable(issues, true)
-			} else {
-				message = render.RenderGroupedTable(issues, parentMap, progress)
-			}
-		}
-		w.Success(result, message)
-
-		return nil
+		return runIssueList(cmd, args, getWriter(cmd))
 	},
+}
+
+func runIssueList(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	statuses, _ := cmd.Flags().GetStringSlice("status")
+	priorities, _ := cmd.Flags().GetStringSlice("priority")
+	labels, _ := cmd.Flags().GetStringSlice("label")
+	types, _ := cmd.Flags().GetStringSlice("type")
+	assignee, _ := cmd.Flags().GetString("assignee")
+	parent, _ := cmd.Flags().GetString("parent")
+	rootsOnly, _ := cmd.Flags().GetBool("roots")
+	treeMode, _ := cmd.Flags().GetBool("tree")
+	sortFlag, _ := cmd.Flags().GetString("sort")
+	limit, _ := cmd.Flags().GetInt("limit")
+	all, _ := cmd.Flags().GetBool("all")
+
+	// Validate filter enum values.
+	for _, s := range statuses {
+		if err := model.ValidateStatus(model.Status(s)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+	for _, p := range priorities {
+		if err := model.ValidatePriority(model.Priority(p)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+	for _, t := range types {
+		if err := model.ValidateIssueKind(model.IssueKind(t)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+
+	opts := db.ListOptions{
+		Statuses:    statuses,
+		Priorities:  priorities,
+		Labels:      labels,
+		Types:       types,
+		Assignee:    assignee,
+		RootsOnly:   rootsOnly,
+		IncludeDone: all,
+		Limit:       limit,
+	}
+
+	// Parse --parent flag.
+	if parent != "" {
+		pid, err := model.ParseID(parent)
+		if err != nil {
+			return cmdErr(fmt.Errorf("invalid parent ID: %w", err), output.ErrValidation)
+		}
+		opts.ParentID = &pid
+	}
+
+	// Parse --sort flag (field:direction).
+	if sortFlag != "" {
+		parts := strings.SplitN(sortFlag, ":", 2)
+		opts.Sort = parts[0]
+		if len(parts) > 1 {
+			opts.SortDir = parts[1]
+		}
+	}
+
+	issues, total, err := db.ListIssues(conn, opts)
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
+	}
+
+	result := listResult{Issues: issues, Total: total}
+
+	// Fetch parent issues and sub-issue progress for the grouped display.
+	// Only needed for human-readable output (JSON stays flat).
+	var parentMap map[int]*model.Issue
+	var progress map[int]render.SubIssueProgress
+	if !w.JSONMode {
+		// Build a set of issue IDs in the result set for quick lookup.
+		resultIDs := make(map[int]struct{}, len(issues))
+		for _, issue := range issues {
+			resultIDs[issue.ID] = struct{}{}
+		}
+
+		// Collect parent IDs that are referenced but not in the result set.
+		missingParentIDs := make(map[int]struct{})
+		for _, issue := range issues {
+			if issue.ParentID != nil {
+				pid := *issue.ParentID
+				if _, inResult := resultIDs[pid]; !inResult {
+					missingParentIDs[pid] = struct{}{}
+				}
+			}
+		}
+
+		// Batch-fetch missing parents if any exist.
+		if len(missingParentIDs) > 0 {
+			ids := make([]int, 0, len(missingParentIDs))
+			for id := range missingParentIDs {
+				ids = append(ids, id)
+			}
+			parentMap, err = db.GetIssuesByIDs(conn, ids)
+			if err != nil {
+				return cmdErr(fmt.Errorf("fetching parent issues: %w", err), output.ErrGeneral)
+			}
+		}
+
+		// Collect IDs of all parent issues that have children in the
+		// result set. This includes parents fetched into parentMap
+		// (excluded by filters) and parents already in the result set.
+		parentIDSet := make(map[int]struct{})
+		for id := range parentMap {
+			parentIDSet[id] = struct{}{}
+		}
+		for _, issue := range issues {
+			if issue.ParentID != nil {
+				pid := *issue.ParentID
+				if _, inResult := resultIDs[pid]; inResult {
+					parentIDSet[pid] = struct{}{}
+				} else if _, inMap := parentMap[pid]; inMap {
+					parentIDSet[pid] = struct{}{}
+				}
+			}
+		}
+
+		// Fetch sub-issue progress (done/total counts) for parent
+		// issues in a single batch query.
+		if len(parentIDSet) > 0 {
+			parentIDs := make([]int, 0, len(parentIDSet))
+			for id := range parentIDSet {
+				parentIDs = append(parentIDs, id)
+			}
+			batchProgress, err := db.GetBatchSubIssueProgress(conn, parentIDs)
+			if err != nil {
+				return cmdErr(fmt.Errorf("fetching sub-issue progress: %w", err), output.ErrGeneral)
+			}
+			progress = make(map[int]render.SubIssueProgress, len(batchProgress))
+			for id, counts := range batchProgress {
+				if counts[1] > 0 {
+					progress[id] = render.SubIssueProgress{Done: counts[0], Total: counts[1]}
+				}
+			}
+		}
+	}
+
+	var message string
+	if !w.JSONMode {
+		if treeMode {
+			message = render.RenderTable(issues, true)
+		} else {
+			message = render.RenderGroupedTable(issues, parentMap, progress)
+		}
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/issue_log.go
+++ b/internal/cli/issue_log.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
@@ -12,7 +16,9 @@ import (
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // logResult is the JSON wire format for the log command output.
@@ -27,61 +33,80 @@ var logCmd = &cobra.Command{
 	Short: "Show activity history for an issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		id, err := model.ParseID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runIssueLog(cmd, args, w)
+			})
 		}
-
-		if _, err := db.GetIssue(conn, id); err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
-		}
-
-		limit, _ := cmd.Flags().GetInt("limit")
-		limit = max(limit, 1)
-
-		activity, err := db.GetActivity(conn, id, limit)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching activity: %w", err), output.ErrGeneral)
-		}
-
-		entries := activity
-		if entries == nil {
-			entries = []model.Activity{}
-		}
-
-		result := logResult{
-			IssueID: model.FormatID(id),
-			Entries: entries,
-			Total:   len(entries),
-		}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		if jsonMode {
-			w.Success(result, "")
-			return nil
-		}
-
-		if len(activity) == 0 {
-			quiet, _ := cmd.Flags().GetBool("quiet")
-			msg := render.EmptyState(
-				fmt.Sprintf("No activity for %s", model.FormatID(id)),
-				"",
-				quiet,
-			)
-			w.Success(result, msg)
-			return nil
-		}
-
-		message := formatActivityLog(model.FormatID(id), activity)
-		w.Success(result, message)
-		return nil
+		return runIssueLog(cmd, args, getWriter(cmd))
 	},
+}
+
+func runIssueLog(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	id, err := model.ParseID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+	}
+
+	if _, err := db.GetIssue(conn, id); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
+	}
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	limit = max(limit, 1)
+
+	activity, err := db.GetActivity(conn, id, limit)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching activity: %w", err), output.ErrGeneral)
+	}
+
+	entries := activity
+	if entries == nil {
+		entries = []model.Activity{}
+	}
+
+	result := logResult{
+		IssueID: model.FormatID(id),
+		Entries: entries,
+		Total:   len(entries),
+	}
+
+	if w.JSONMode {
+		w.Success(result, "")
+		return nil
+	}
+
+	if len(activity) == 0 {
+		msg := render.EmptyState(
+			fmt.Sprintf("No activity for %s", model.FormatID(id)),
+			"",
+			w.QuietMode,
+		)
+		w.Success(result, msg)
+		return nil
+	}
+
+	message := formatActivityLog(model.FormatID(id), activity)
+	w.Success(result, message)
+	return nil
 }
 
 func formatActivityLog(issueID string, activity []model.Activity) string {

--- a/internal/cli/issue_show.go
+++ b/internal/cli/issue_show.go
@@ -1,16 +1,22 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // showResult composes the issue fields with additional detail fields
@@ -103,71 +109,91 @@ var showCmd = &cobra.Command{
 	Short: "Show issue details",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		id, err := model.ParseID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runIssueShow(cmd, args, w)
+			})
 		}
-
-		issue, err := db.GetIssue(conn, id)
-		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
-		}
-
-		// Hydrate labels.
-		issue.Labels, err = db.GetIssueLabels(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching labels: %w", err), output.ErrGeneral)
-		}
-
-		// Hydrate files.
-		issue.Files, err = db.GetIssueFiles(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching files: %w", err), output.ErrGeneral)
-		}
-
-		subIssues, err := db.GetSubIssues(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching sub-issues: %w", err), output.ErrGeneral)
-		}
-
-		relations, err := db.GetIssueRelations(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
-		}
-
-		comments, err := db.ListComments(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching comments: %w", err), output.ErrGeneral)
-		}
-
-		activity, err := db.GetActivity(conn, id, 10)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching activity: %w", err), output.ErrGeneral)
-		}
-
-		result := showResult{
-			Issue:     issue,
-			SubIssues: subIssues,
-			Relations: relations,
-			Comments:  comments,
-			Activity:  activity,
-		}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		var message string
-		if !jsonMode {
-			message = render.RenderDetail(issue, subIssues, relations, comments, activity)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runIssueShow(cmd, args, getWriter(cmd))
 	},
+}
+
+func runIssueShow(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	id, err := model.ParseID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid issue ID: %w", err), output.ErrValidation)
+	}
+
+	issue, err := db.GetIssue(conn, id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("issue %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching issue: %w", err), output.ErrGeneral)
+	}
+
+	// Hydrate labels.
+	issue.Labels, err = db.GetIssueLabels(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching labels: %w", err), output.ErrGeneral)
+	}
+
+	// Hydrate files.
+	issue.Files, err = db.GetIssueFiles(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching files: %w", err), output.ErrGeneral)
+	}
+
+	subIssues, err := db.GetSubIssues(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching sub-issues: %w", err), output.ErrGeneral)
+	}
+
+	relations, err := db.GetIssueRelations(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
+	}
+
+	comments, err := db.ListComments(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching comments: %w", err), output.ErrGeneral)
+	}
+
+	activity, err := db.GetActivity(conn, id, 10)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching activity: %w", err), output.ErrGeneral)
+	}
+
+	result := showResult{
+		Issue:     issue,
+		SubIssues: subIssues,
+		Relations: relations,
+		Comments:  comments,
+		Activity:  activity,
+	}
+
+	var message string
+	if !w.JSONMode {
+		message = render.RenderDetail(issue, subIssues, relations, comments, activity)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/next.go
+++ b/internal/cli/next.go
@@ -1,7 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/filter"
@@ -9,6 +15,7 @@ import (
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/planner"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -21,76 +28,96 @@ var nextCmd = &cobra.Command{
 	Use:   "next",
 	Short: "Show work-ready issues",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		statuses, _ := cmd.Flags().GetStringSlice("status")
-		priorities, _ := cmd.Flags().GetStringSlice("priority")
-		labels, _ := cmd.Flags().GetStringSlice("label")
-		types, _ := cmd.Flags().GetStringSlice("type")
-		limit, _ := cmd.Flags().GetInt("limit")
-
-		// Validate filter enum values.
-		for _, s := range statuses {
-			if err := model.ValidateStatus(model.Status(s)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runNext(cmd, args, w)
+			})
 		}
-		for _, p := range priorities {
-			if err := model.ValidatePriority(model.Priority(p)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
-		}
-		for _, t := range types {
-			if err := model.ValidateIssueKind(model.IssueKind(t)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
-		}
-
-		// Fetch all non-done issues for DAG construction.
-		allIssues, _, err := db.ListIssues(conn, db.ListOptions{
-			IncludeDone: false,
-			Limit:       0, // no limit — need all for DAG
-		})
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
-		}
-
-		// Fetch all directional relations (blocks / depends_on).
-		relations, err := db.GetAllDirectionalRelations(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("loading relations: %w", err), output.ErrGeneral)
-		}
-
-		// Build DAG and find work-ready issues.
-		dag := planner.BuildDAG(allIssues, relations)
-
-		// Default statuses for FindReady: backlog, todo.
-		readyStatuses := statuses
-		if len(readyStatuses) == 0 {
-			readyStatuses = []string{string(model.StatusBacklog), string(model.StatusTodo)}
-		}
-		ready := planner.FindReady(dag, readyStatuses)
-
-		// Apply additional filters (priority, label, type) on the ready set.
-		ready = filterReady(ready, priorities, labels, types)
-
-		// Apply limit.
-		if limit > 0 && len(ready) > limit {
-			ready = ready[:limit]
-		}
-
-		result := nextResult{Issues: ready, Total: len(ready)}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		var message string
-		if !jsonMode {
-			message = render.RenderTable(ready, false)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runNext(cmd, args, getWriter(cmd))
 	},
+}
+
+func runNext(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	statuses, _ := cmd.Flags().GetStringSlice("status")
+	priorities, _ := cmd.Flags().GetStringSlice("priority")
+	labels, _ := cmd.Flags().GetStringSlice("label")
+	types, _ := cmd.Flags().GetStringSlice("type")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	// Validate filter enum values.
+	for _, s := range statuses {
+		if err := model.ValidateStatus(model.Status(s)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+	for _, p := range priorities {
+		if err := model.ValidatePriority(model.Priority(p)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+	for _, t := range types {
+		if err := model.ValidateIssueKind(model.IssueKind(t)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+
+	// Fetch all non-done issues for DAG construction.
+	allIssues, _, err := db.ListIssues(conn, db.ListOptions{
+		IncludeDone: false,
+		Limit:       0, // no limit — need all for DAG
+	})
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
+	}
+
+	// Fetch all directional relations (blocks / depends_on).
+	relations, err := db.GetAllDirectionalRelations(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("loading relations: %w", err), output.ErrGeneral)
+	}
+
+	// Build DAG and find work-ready issues.
+	dag := planner.BuildDAG(allIssues, relations)
+
+	// Default statuses for FindReady: backlog, todo.
+	readyStatuses := statuses
+	if len(readyStatuses) == 0 {
+		readyStatuses = []string{string(model.StatusBacklog), string(model.StatusTodo)}
+	}
+	ready := planner.FindReady(dag, readyStatuses)
+
+	// Apply additional filters (priority, label, type) on the ready set.
+	ready = filterReady(ready, priorities, labels, types)
+
+	// Apply limit.
+	if limit > 0 && len(ready) > limit {
+		ready = ready[:limit]
+	}
+
+	result := nextResult{Issues: ready, Total: len(ready)}
+
+	var message string
+	if !w.JSONMode {
+		message = render.RenderTable(ready, false)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 // filterReady applies priority, label, and type filters to a slice of ready issues.

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -1,10 +1,16 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"sort"
 	"strings"
+	"syscall"
+
+	"golang.org/x/term"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -13,6 +19,7 @@ import (
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/planner"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -34,93 +41,113 @@ var planCmd = &cobra.Command{
 	Use:   "plan",
 	Short: "Show execution plan with phased grouping",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		statuses, _ := cmd.Flags().GetStringSlice("status")
-		labels, _ := cmd.Flags().GetStringSlice("label")
-		rootFlag, _ := cmd.Flags().GetString("root")
-
-		// Validate status filter values.
-		for _, s := range statuses {
-			if err := model.ValidateStatus(model.Status(s)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runPlan(cmd, args, w)
+			})
 		}
-
-		// Fetch all non-done issues.
-		issues, _, err := db.ListIssues(conn, db.ListOptions{
-			IncludeDone: false,
-			Limit:       0,
-		})
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
-		}
-
-		// Hydrate file attachments so the planner can detect file collisions.
-		if err := db.HydrateFiles(conn, issues); err != nil {
-			return cmdErr(fmt.Errorf("hydrating files: %w", err), output.ErrGeneral)
-		}
-
-		// Fetch all directional relations.
-		relations, err := db.GetAllDirectionalRelations(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
-		}
-
-		// Build the DAG.
-		dag := planner.BuildDAG(issues, relations)
-
-		// Build plan filters.
-		filters := planner.PlanFilters{
-			Statuses: statuses,
-			Labels:   labels,
-		}
-
-		// Parse --root flag.
-		if rootFlag != "" {
-			rootID, err := model.ParseID(rootFlag)
-			if err != nil {
-				return cmdErr(fmt.Errorf("invalid root ID: %w", err), output.ErrValidation)
-			}
-			filters.RootID = &rootID
-		}
-
-		// Generate the plan (includes cycle detection via TopoSort).
-		plan, err := planner.GeneratePlan(dag, filters)
-		if err != nil {
-			var cycleErr *planner.CycleError
-			if errors.As(err, &cycleErr) {
-				return cmdErr(err, output.ErrConflict)
-			}
-			return cmdErr(fmt.Errorf("generating plan: %w", err), output.ErrGeneral)
-		}
-
-		// Build JSON result.
-		phases := make([]planPhaseJSON, len(plan.Phases))
-		for i, phase := range plan.Phases {
-			phases[i] = planPhaseJSON{
-				Phase:  phase.Number,
-				Issues: phase.Issues,
-			}
-		}
-
-		result := planResult{
-			Phases:         phases,
-			TotalIssues:    plan.TotalIssues,
-			TotalPhases:    plan.TotalPhases,
-			MaxParallelism: plan.MaxParallelism,
-		}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		var message string
-		if !jsonMode {
-			message = renderPlanHuman(plan, dag)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runPlan(cmd, args, getWriter(cmd))
 	},
+}
+
+func runPlan(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	statuses, _ := cmd.Flags().GetStringSlice("status")
+	labels, _ := cmd.Flags().GetStringSlice("label")
+	rootFlag, _ := cmd.Flags().GetString("root")
+
+	// Validate status filter values.
+	for _, s := range statuses {
+		if err := model.ValidateStatus(model.Status(s)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+
+	// Fetch all non-done issues.
+	issues, _, err := db.ListIssues(conn, db.ListOptions{
+		IncludeDone: false,
+		Limit:       0,
+	})
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing issues: %w", err), output.ErrGeneral)
+	}
+
+	// Hydrate file attachments so the planner can detect file collisions.
+	if err := db.HydrateFiles(conn, issues); err != nil {
+		return cmdErr(fmt.Errorf("hydrating files: %w", err), output.ErrGeneral)
+	}
+
+	// Fetch all directional relations.
+	relations, err := db.GetAllDirectionalRelations(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching relations: %w", err), output.ErrGeneral)
+	}
+
+	// Build the DAG.
+	dag := planner.BuildDAG(issues, relations)
+
+	// Build plan filters.
+	filters := planner.PlanFilters{
+		Statuses: statuses,
+		Labels:   labels,
+	}
+
+	// Parse --root flag.
+	if rootFlag != "" {
+		rootID, err := model.ParseID(rootFlag)
+		if err != nil {
+			return cmdErr(fmt.Errorf("invalid root ID: %w", err), output.ErrValidation)
+		}
+		filters.RootID = &rootID
+	}
+
+	// Generate the plan (includes cycle detection via TopoSort).
+	plan, err := planner.GeneratePlan(dag, filters)
+	if err != nil {
+		var cycleErr *planner.CycleError
+		if errors.As(err, &cycleErr) {
+			return cmdErr(err, output.ErrConflict)
+		}
+		return cmdErr(fmt.Errorf("generating plan: %w", err), output.ErrGeneral)
+	}
+
+	// Build JSON result.
+	phases := make([]planPhaseJSON, len(plan.Phases))
+	for i, phase := range plan.Phases {
+		phases[i] = planPhaseJSON{
+			Phase:  phase.Number,
+			Issues: phase.Issues,
+		}
+	}
+
+	result := planResult{
+		Phases:         phases,
+		TotalIssues:    plan.TotalIssues,
+		TotalPhases:    plan.TotalPhases,
+		MaxParallelism: plan.MaxParallelism,
+	}
+
+	var message string
+	if !w.JSONMode {
+		message = renderPlanHuman(plan, dag)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 // renderPlanHuman renders the execution plan as human-readable text.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ALT-F4-LLC/docket/internal/config"
 	"github.com/ALT-F4-LLC/docket/internal/db"
@@ -50,6 +51,23 @@ var rootCmd = &cobra.Command{
 
 		ctx := context.WithValue(cmd.Context(), cfgKey, cfg)
 
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			if !isWatchEligible(cmd) {
+				return cmdErr(
+					fmt.Errorf("--watch is not supported on write commands"),
+					output.ErrValidation,
+				)
+			}
+			interval, _ := cmd.Flags().GetDuration("interval")
+			if interval < 500*time.Millisecond {
+				return cmdErr(
+					fmt.Errorf("--interval must be at least 500ms"),
+					output.ErrValidation,
+				)
+			}
+		}
+
 		if _, ok := cmd.Annotations["skipDB"]; ok {
 			cmd.SetContext(ctx)
 			return nil
@@ -86,8 +104,16 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().Bool("json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output")
+	rootCmd.PersistentFlags().BoolP("watch", "w", false, "Watch for changes and refresh output")
+	rootCmd.PersistentFlags().Duration("interval", 2*time.Second, "Refresh interval for --watch")
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
+}
+
+// initWatchFlags must be called after all subcommands are registered to hide
+// --watch and --interval on ineligible commands. This is invoked from Execute.
+func initWatchFlags() {
+	hideWatchFlags(rootCmd)
 }
 
 func getWriter(cmd *cobra.Command) *output.Writer {
@@ -111,6 +137,7 @@ func getDB(cmd *cobra.Command) *sql.DB {
 
 // Execute runs the root command and returns an exit code.
 func Execute() int {
+	initWatchFlags()
 	if err := rootCmd.Execute(); err != nil {
 		jsonMode, _ := rootCmd.PersistentFlags().GetBool("json")
 		quietMode, _ := rootCmd.PersistentFlags().GetBool("quiet")

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -1,14 +1,21 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+
+	"golang.org/x/term"
 
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -30,56 +37,77 @@ var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Show summary statistics for the issue database",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		total, err := db.CountIssues(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("counting issues: %w", err), output.ErrGeneral)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runStats(cmd, args, w)
+			})
 		}
-
-		rootCount, err := db.CountRootIssues(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("counting root issues: %w", err), output.ErrGeneral)
-		}
-
-		byStatus, err := db.CountByStatus(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("counting by status: %w", err), output.ErrGeneral)
-		}
-
-		byPriority, err := db.CountByPriority(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("counting by priority: %w", err), output.ErrGeneral)
-		}
-
-		labels, err := db.ListAllLabels(conn)
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing labels: %w", err), output.ErrGeneral)
-		}
-
-		labelStats := make([]labelStat, len(labels))
-		for i, l := range labels {
-			labelStats[i] = labelStat{Name: l.Name, Count: l.IssueCount}
-		}
-
-		result := statsResult{
-			Total:      total,
-			RootIssues: rootCount,
-			SubIssues:  total - rootCount,
-			ByStatus:   byStatus,
-			ByPriority: byPriority,
-			Labels:     labelStats,
-		}
-
-		var message string
-		if !w.JSONMode {
-			message = renderStats(result)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runStats(cmd, args, getWriter(cmd))
 	},
+}
+
+func runStats(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	total, err := db.CountIssues(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("counting issues: %w", err), output.ErrGeneral)
+	}
+
+	rootCount, err := db.CountRootIssues(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("counting root issues: %w", err), output.ErrGeneral)
+	}
+
+	byStatus, err := db.CountByStatus(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("counting by status: %w", err), output.ErrGeneral)
+	}
+
+	byPriority, err := db.CountByPriority(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("counting by priority: %w", err), output.ErrGeneral)
+	}
+
+	labels, err := db.ListAllLabels(conn)
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing labels: %w", err), output.ErrGeneral)
+	}
+
+	labelStats := make([]labelStat, len(labels))
+	for i, l := range labels {
+		labelStats[i] = labelStat{Name: l.Name, Count: l.IssueCount}
+	}
+
+	result := statsResult{
+		Total:      total,
+		RootIssues: rootCount,
+		SubIssues:  total - rootCount,
+		ByStatus:   byStatus,
+		ByPriority: byPriority,
+		Labels:     labelStats,
+	}
+
+	var message string
+	if !w.JSONMode {
+		message = renderStats(result)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/vote_list.go
+++ b/internal/cli/vote_list.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type voteListResult struct {
@@ -21,68 +27,89 @@ var voteListCmd = &cobra.Command{
 	Short:   "List proposals",
 	Aliases: []string{"ls"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		status, _ := cmd.Flags().GetString("status")
-		criticality, _ := cmd.Flags().GetString("criticality")
-		domainTag, _ := cmd.Flags().GetString("domain-tag")
-		all, _ := cmd.Flags().GetBool("all")
-		limit, _ := cmd.Flags().GetInt("limit")
-
-		// Validate filter enum values.
-		if status != "" {
-			if err := model.ValidateProposalStatus(model.ProposalStatus(status)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runVoteList(cmd, args, w)
+			})
 		}
-		if criticality != "" {
-			if err := model.ValidateCriticality(model.Criticality(criticality)); err != nil {
-				return cmdErr(err, output.ErrValidation)
-			}
-		}
-
-		// Default behavior: show only open proposals unless --all or explicit --status.
-		if !all && status == "" {
-			status = string(model.ProposalStatusOpen)
-		}
-		// If --all is set with no explicit status, clear the status filter.
-		if all && !cmd.Flags().Changed("status") {
-			status = ""
-		}
-
-		proposals, total, err := db.ListProposals(conn, status, criticality, domainTag, limit)
-		if err != nil {
-			return cmdErr(fmt.Errorf("listing proposals: %w", err), output.ErrGeneral)
-		}
-
-		if proposals == nil {
-			proposals = []*model.Proposal{}
-		}
-
-		result := voteListResult{Proposals: proposals, Total: total}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		var message string
-		if !jsonMode {
-			// Fetch vote counts per proposal for human-readable output.
-			voteCounts, err := getVoteCounts(conn, proposals)
-			if err != nil {
-				return cmdErr(fmt.Errorf("fetching vote counts: %w", err), output.ErrGeneral)
-			}
-			rows := make([]render.ProposalRow, 0, len(proposals))
-			for _, p := range proposals {
-				rows = append(rows, render.ProposalRow{
-					Proposal: p,
-					VoteCast: voteCounts[p.ID],
-				})
-			}
-			message = render.RenderProposalTable(rows)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runVoteList(cmd, args, getWriter(cmd))
 	},
+}
+
+// runVoteList contains the query + render + output logic for vote list.
+func runVoteList(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	status, _ := cmd.Flags().GetString("status")
+	criticality, _ := cmd.Flags().GetString("criticality")
+	domainTag, _ := cmd.Flags().GetString("domain-tag")
+	all, _ := cmd.Flags().GetBool("all")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	// Validate filter enum values.
+	if status != "" {
+		if err := model.ValidateProposalStatus(model.ProposalStatus(status)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+	if criticality != "" {
+		if err := model.ValidateCriticality(model.Criticality(criticality)); err != nil {
+			return cmdErr(err, output.ErrValidation)
+		}
+	}
+
+	// Default behavior: show only open proposals unless --all or explicit --status.
+	if !all && status == "" {
+		status = string(model.ProposalStatusOpen)
+	}
+	// If --all is set with no explicit status, clear the status filter.
+	if all && !cmd.Flags().Changed("status") {
+		status = ""
+	}
+
+	proposals, total, err := db.ListProposals(conn, status, criticality, domainTag, limit)
+	if err != nil {
+		return cmdErr(fmt.Errorf("listing proposals: %w", err), output.ErrGeneral)
+	}
+
+	if proposals == nil {
+		proposals = []*model.Proposal{}
+	}
+
+	result := voteListResult{Proposals: proposals, Total: total}
+
+	var message string
+	if !w.JSONMode {
+		// Fetch vote counts per proposal for human-readable output.
+		voteCounts, err := getVoteCounts(conn, proposals)
+		if err != nil {
+			return cmdErr(fmt.Errorf("fetching vote counts: %w", err), output.ErrGeneral)
+		}
+		rows := make([]render.ProposalRow, 0, len(proposals))
+		for _, p := range proposals {
+			rows = append(rows, render.ProposalRow{
+				Proposal: p,
+				VoteCast: voteCounts[p.ID],
+			})
+		}
+		message = render.RenderProposalTable(rows)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 // getVoteCounts returns a map of proposal ID to votes cast count.

--- a/internal/cli/vote_result.go
+++ b/internal/cli/vote_result.go
@@ -1,15 +1,21 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // voteResultData is the JSON wire format for vote result output.
@@ -40,52 +46,73 @@ var voteResultCmd = &cobra.Command{
 	Short: "Show consensus result for a proposal",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		proposalID, err := model.ParseProposalID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid proposal ID: %w", err), output.ErrValidation)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runVoteResult(cmd, args, w)
+			})
 		}
-
-		proposal, err := db.GetProposal(conn, proposalID)
-		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("proposal %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching proposal: %w", err), output.ErrGeneral)
-		}
-
-		votes, err := db.GetProposalVotes(conn, proposalID)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching votes: %w", err), output.ErrGeneral)
-		}
-
-		votesCast := len(votes)
-		quorumReached := votesCast >= proposal.RequiredVoters
-
-		result := voteResultData{
-			ID:               model.FormatProposalID(proposal.ID),
-			Status:           string(proposal.Status),
-			FinalOutcome:     proposal.FinalOutcome,
-			EscalationReason: proposal.EscalationReason,
-			WeightedScore:    proposal.WeightedScore,
-			Threshold:        proposal.Threshold,
-			VotesCast:        votesCast,
-			VotesRequired:    proposal.RequiredVoters,
-			QuorumReached:    quorumReached,
-			Votes:            votes,
-		}
-
-		var message string
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		if !jsonMode {
-			message = render.RenderVoteResult(proposal, votes)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runVoteResult(cmd, args, getWriter(cmd))
 	},
+}
+
+// runVoteResult contains the query + render + output logic for vote result.
+func runVoteResult(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	proposalID, err := model.ParseProposalID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid proposal ID: %w", err), output.ErrValidation)
+	}
+
+	proposal, err := db.GetProposal(conn, proposalID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("proposal %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching proposal: %w", err), output.ErrGeneral)
+	}
+
+	votes, err := db.GetProposalVotes(conn, proposalID)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching votes: %w", err), output.ErrGeneral)
+	}
+
+	votesCast := len(votes)
+	quorumReached := votesCast >= proposal.RequiredVoters
+
+	result := voteResultData{
+		ID:               model.FormatProposalID(proposal.ID),
+		Status:           string(proposal.Status),
+		FinalOutcome:     proposal.FinalOutcome,
+		EscalationReason: proposal.EscalationReason,
+		WeightedScore:    proposal.WeightedScore,
+		Threshold:        proposal.Threshold,
+		VotesCast:        votesCast,
+		VotesRequired:    proposal.RequiredVoters,
+		QuorumReached:    quorumReached,
+		Votes:            votes,
+	}
+
+	var message string
+	if !w.JSONMode {
+		message = render.RenderVoteResult(proposal, votes)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/vote_show.go
+++ b/internal/cli/vote_show.go
@@ -1,16 +1,22 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/ALT-F4-LLC/docket/internal/db"
 	"github.com/ALT-F4-LLC/docket/internal/model"
 	"github.com/ALT-F4-LLC/docket/internal/output"
 	"github.com/ALT-F4-LLC/docket/internal/render"
+	"github.com/ALT-F4-LLC/docket/internal/watch"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // voteShowResult composes a proposal with its votes and linked issues
@@ -92,47 +98,68 @@ var voteShowCmd = &cobra.Command{
 	Short: "Show proposal details",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		w := getWriter(cmd)
-		conn := getDB(cmd)
-
-		id, err := model.ParseProposalID(args[0])
-		if err != nil {
-			return cmdErr(fmt.Errorf("invalid proposal ID: %w", err), output.ErrValidation)
+		watchMode, _ := cmd.Flags().GetBool("watch")
+		if watchMode {
+			interval, _ := cmd.Flags().GetDuration("interval")
+			jsonMode, _ := cmd.Flags().GetBool("json")
+			quietMode, _ := cmd.Flags().GetBool("quiet")
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return watch.RunWatch(ctx, watch.Options{
+				Interval:  interval,
+				JSONMode:  jsonMode,
+				QuietMode: quietMode,
+				IsTTY:     term.IsTerminal(int(os.Stdout.Fd())),
+				Stdout:    os.Stdout,
+				Stderr:    os.Stderr,
+			}, func(ctx context.Context, w *output.Writer) error {
+				return runVoteShow(cmd, args, w)
+			})
 		}
-
-		proposal, err := db.GetProposal(conn, id)
-		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return cmdErr(fmt.Errorf("proposal %s not found", args[0]), output.ErrNotFound)
-			}
-			return cmdErr(fmt.Errorf("fetching proposal: %w", err), output.ErrGeneral)
-		}
-
-		votes, err := db.GetProposalVotes(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching votes: %w", err), output.ErrGeneral)
-		}
-
-		linkedIssues, err := db.GetProposalIssues(conn, id)
-		if err != nil {
-			return cmdErr(fmt.Errorf("fetching linked issues: %w", err), output.ErrGeneral)
-		}
-
-		result := voteShowResult{
-			Proposal:     proposal,
-			Votes:        votes,
-			LinkedIssues: linkedIssues,
-		}
-
-		jsonMode, _ := cmd.Flags().GetBool("json")
-		var message string
-		if !jsonMode {
-			message = render.RenderProposalDetail(proposal, votes, linkedIssues)
-		}
-		w.Success(result, message)
-
-		return nil
+		return runVoteShow(cmd, args, getWriter(cmd))
 	},
+}
+
+// runVoteShow contains the query + render + output logic for vote show.
+func runVoteShow(cmd *cobra.Command, args []string, w *output.Writer) error {
+	conn := getDB(cmd)
+
+	id, err := model.ParseProposalID(args[0])
+	if err != nil {
+		return cmdErr(fmt.Errorf("invalid proposal ID: %w", err), output.ErrValidation)
+	}
+
+	proposal, err := db.GetProposal(conn, id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return cmdErr(fmt.Errorf("proposal %s not found", args[0]), output.ErrNotFound)
+		}
+		return cmdErr(fmt.Errorf("fetching proposal: %w", err), output.ErrGeneral)
+	}
+
+	votes, err := db.GetProposalVotes(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching votes: %w", err), output.ErrGeneral)
+	}
+
+	linkedIssues, err := db.GetProposalIssues(conn, id)
+	if err != nil {
+		return cmdErr(fmt.Errorf("fetching linked issues: %w", err), output.ErrGeneral)
+	}
+
+	result := voteShowResult{
+		Proposal:     proposal,
+		Votes:        votes,
+		LinkedIssues: linkedIssues,
+	}
+
+	var message string
+	if !w.JSONMode {
+		message = render.RenderProposalDetail(proposal, votes, linkedIssues)
+	}
+	w.Success(result, message)
+
+	return nil
 }
 
 func init() {

--- a/internal/cli/watch_commands.go
+++ b/internal/cli/watch_commands.go
@@ -1,0 +1,37 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+// watchEligible is the set of command paths that support --watch mode.
+// Keys are Cobra CommandPath() values for unambiguous matching.
+var watchEligible = map[string]bool{
+	"docket board":                true,
+	"docket issue list":           true,
+	"docket issue show":           true,
+	"docket issue log":            true,
+	"docket issue graph":          true,
+	"docket issue comment list":   true,
+	"docket next":                 true,
+	"docket plan":                 true,
+	"docket stats":                true,
+	"docket config":               true,
+	"docket vote list":            true,
+	"docket vote show":            true,
+	"docket vote result":          true,
+}
+
+func isWatchEligible(cmd *cobra.Command) bool {
+	return watchEligible[cmd.CommandPath()]
+}
+
+// hideWatchFlags hides --watch and --interval on commands that are not
+// watch-eligible. Called during init after all subcommands are registered.
+func hideWatchFlags(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		hideWatchFlags(child)
+	}
+	if cmd != rootCmd && !isWatchEligible(cmd) {
+		cmd.Flags().MarkHidden("watch")
+		cmd.Flags().MarkHidden("interval")
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,94 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/ALT-F4-LLC/docket/internal/output"
+)
+
+// Options configures the watch loop behavior.
+type Options struct {
+	Interval  time.Duration
+	JSONMode  bool
+	QuietMode bool
+	IsTTY     bool
+	Stdout    io.Writer
+	Stderr    io.Writer
+}
+
+// RunWatch executes fn repeatedly on the given interval until ctx is cancelled.
+// It handles terminal clearing, output buffering, and newline separation.
+// On each cycle, RunWatch creates a fresh output.Writer backed by a shared
+// bytes.Buffer and passes it to fn. After fn returns, RunWatch clears the
+// screen (if TTY) and flushes the buffer to real stdout atomically.
+func RunWatch(ctx context.Context, opts Options, fn func(ctx context.Context, w *output.Writer) error) error {
+	var buf bytes.Buffer
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+
+	var consecutiveErrors int
+	const maxConsecutiveErrors = 3
+
+	for cycle := 0; ; cycle++ {
+		buf.Reset()
+
+		w := &output.Writer{
+			JSONMode:  opts.JSONMode,
+			QuietMode: opts.QuietMode,
+			Stdout:    &buf,
+			Stderr:    opts.Stderr,
+		}
+
+		if err := fn(ctx, w); err != nil {
+			consecutiveErrors++
+			fmt.Fprintf(opts.Stderr, "Error: %v\n", err)
+			if consecutiveErrors >= maxConsecutiveErrors {
+				return fmt.Errorf("watch: %d consecutive errors, last: %w", maxConsecutiveErrors, err)
+			}
+		} else {
+			consecutiveErrors = 0
+		}
+
+		if cycle == 0 {
+			// First cycle: write directly to stdout.
+			buf.WriteTo(opts.Stdout)
+		} else {
+			if opts.JSONMode {
+				// JSON mode: flush buffer directly (NDJSON).
+				buf.WriteTo(opts.Stdout)
+			} else if opts.IsTTY {
+				// Human + TTY: ANSI clear, optional status line, flush.
+				fmt.Fprint(opts.Stdout, "\033[2J\033[H")
+				if !opts.QuietMode {
+					fmt.Fprintf(opts.Stdout, "Watching every %s... (last update: %s) [Ctrl+C to exit]\n\n",
+						formatInterval(opts.Interval),
+						time.Now().Format("15:04:05"),
+					)
+				}
+				buf.WriteTo(opts.Stdout)
+			} else {
+				// Human + non-TTY: blank line separator, flush.
+				fmt.Fprintln(opts.Stdout)
+				buf.WriteTo(opts.Stdout)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// formatInterval formats a duration for the status line.
+func formatInterval(d time.Duration) string {
+	if d >= time.Second && d%time.Second == 0 {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return d.String()
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,328 @@
+package watch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALT-F4-LLC/docket/internal/output"
+)
+
+func TestRunWatch_CallsFnImmediately(t *testing.T) {
+	var called bool
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval: 50 * time.Millisecond,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		called = true
+		fmt.Fprintln(w.Stdout, "hello")
+		cancel()
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("fn was not called on first cycle")
+	}
+	if !strings.Contains(stdout.String(), "hello") {
+		t.Fatalf("expected stdout to contain 'hello', got: %q", stdout.String())
+	}
+}
+
+func TestRunWatch_CallsFnAfterInterval(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		fmt.Fprintln(w.Stdout, "tick")
+		if callCount >= 3 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount < 3 {
+		t.Fatalf("expected at least 3 calls, got %d", callCount)
+	}
+}
+
+func TestRunWatch_ReturnsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		fmt.Fprintln(w.Stdout, "once")
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error on context cancel, got: %v", err)
+	}
+}
+
+func TestRunWatch_TTYEmitsANSIClear(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		IsTTY:    true,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		fmt.Fprintln(w.Stdout, "data")
+		if callCount >= 2 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "\033[2J\033[H") {
+		t.Fatalf("expected ANSI clear sequence in TTY output, got: %q", out)
+	}
+}
+
+func TestRunWatch_NonTTYEmitsBlankLineSeparator(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		IsTTY:    false,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		fmt.Fprintln(w.Stdout, "line")
+		if callCount >= 2 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "line\n\nline\n") {
+		t.Fatalf("expected blank line separator in non-TTY output, got: %q", out)
+	}
+	if strings.Contains(out, "\033[") {
+		t.Fatal("non-TTY output should not contain ANSI sequences")
+	}
+}
+
+func TestRunWatch_JSONModeNoANSI(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		JSONMode: true,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		fmt.Fprintln(w.Stdout, `{"ok":true}`)
+		if callCount >= 2 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "\033[") {
+		t.Fatal("JSON mode output should not contain ANSI sequences")
+	}
+	if strings.Contains(out, "Watching") {
+		t.Fatal("JSON mode output should not contain status line")
+	}
+}
+
+func TestRunWatch_QuietModeSuppressesStatusLine(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval:  10 * time.Millisecond,
+		IsTTY:     true,
+		QuietMode: true,
+		Stdout:    &stdout,
+		Stderr:    &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		fmt.Fprintln(w.Stdout, "data")
+		if callCount >= 2 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "Watching") {
+		t.Fatal("quiet mode should suppress the status line")
+	}
+	// Should still have ANSI clear in TTY mode
+	if !strings.Contains(out, "\033[2J\033[H") {
+		t.Fatal("quiet mode should still emit ANSI clear in TTY mode")
+	}
+}
+
+func TestRunWatch_SingleErrorContinues(t *testing.T) {
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stderr bytes.Buffer
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &stderr,
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		if callCount == 1 {
+			return fmt.Errorf("transient failure")
+		}
+		fmt.Fprintln(w.Stdout, "recovered")
+		cancel()
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount < 2 {
+		t.Fatal("expected watch to continue after single error")
+	}
+	if !strings.Contains(stderr.String(), "transient failure") {
+		t.Fatal("expected error to be printed to stderr")
+	}
+}
+
+func TestRunWatch_ThreeConsecutiveErrorsExits(t *testing.T) {
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		Stdout:   &bytes.Buffer{},
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(context.Background(), opts, func(_ context.Context, w *output.Writer) error {
+		return fmt.Errorf("persistent failure")
+	})
+
+	if err == nil {
+		t.Fatal("expected error after 3 consecutive failures")
+	}
+	if !strings.Contains(err.Error(), "3 consecutive errors") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunWatch_BufferReused(t *testing.T) {
+	// Verify the buffer is allocated once by checking that RunWatch
+	// completes multiple cycles without issues (indirect test — the
+	// implementation uses buf.Reset() rather than allocating a new buffer).
+	var callCount int
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var stdout bytes.Buffer
+	opts := Options{
+		Interval: 10 * time.Millisecond,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+
+	err := RunWatch(ctx, opts, func(_ context.Context, w *output.Writer) error {
+		callCount++
+		// Write different content each cycle to verify buffer is reset
+		fmt.Fprintf(w.Stdout, "cycle-%d\n", callCount)
+		if callCount >= 3 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	// Each cycle should have its own content, not accumulated
+	if strings.Contains(out, "cycle-1cycle-1") {
+		t.Fatal("buffer appears to accumulate content instead of being reset")
+	}
+}
+
+func TestFormatInterval(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{2 * time.Second, "2s"},
+		{5 * time.Second, "5s"},
+		{500 * time.Millisecond, "500ms"},
+		{1500 * time.Millisecond, "1.5s"},
+	}
+
+	for _, tt := range tests {
+		got := formatInterval(tt.d)
+		if got != tt.want {
+			t.Errorf("formatInterval(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--watch` / `-w` flag to all 13 read subcommands (`board`, `issue list/show/log/graph`, `issue comment list`, `next`, `plan`, `stats`, `config`, `vote list/show/result`) for polling-based real-time refresh
- Add `--interval` flag (default 2s, min 500ms) for configurable polling frequency
- New `internal/watch` package with `RunWatch` polling loop featuring output buffering (flicker-free), ANSI terminal clear (TTY), blank line separation (non-TTY), NDJSON streaming for `--json` mode, and 3-consecutive-error recovery
- Extract command logic into `runXxx` functions accepting `*output.Writer` for buffer-backed atomic rendering
- Validate `--watch` on write commands returns `ErrValidation`; graceful Ctrl+C exit via `signal.NotifyContext`

## Test plan

- [x] 11 unit tests in `internal/watch/watch_test.go` covering all modes (TTY, non-TTY, JSON, quiet, error recovery, buffer reuse, context cancellation)
- [x] Full test suite passes (pre-existing failure in `internal/db` is unrelated)
- [x] Manual: `docket board --watch` in TTY — verify smooth clear and reprint
- [x] Manual: create/move issues in second terminal — verify board updates
- [x] Manual: `docket board --watch --json | head -3` — verify 3 valid NDJSON lines
- [x] Manual: `docket issue create --watch` — verify validation error
- [x] Manual: `--interval 100ms` — verify minimum interval rejection
- [x] Manual: Ctrl+C during watch — verify clean exit